### PR TITLE
Refactoring

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -7,10 +7,9 @@
 package main
 
 import (
+	"github.com/edgexfoundry/device-sdk-go/pkg/startup"
 	"github.com/edgexfoundry/device-virtual-go"
 	"github.com/edgexfoundry/device-virtual-go/driver"
-
-	"github.com/edgexfoundry/device-sdk-go/pkg/startup"
 )
 
 const (
@@ -19,6 +18,6 @@ const (
 )
 
 func main() {
-	d := driver.VirtualDriver{}
-	startup.Bootstrap(serviceName, version, &d)
+	d := driver.NewVirtualDeviceDriver()
+	startup.Bootstrap(serviceName, version, d)
 }

--- a/cmd/res/configuration.toml
+++ b/cmd/res/configuration.toml
@@ -10,11 +10,19 @@ EnableAsyncReadings = true
 AsyncBufferSize = 16
 
 [Registry]
+Type = "consul"
 Host = "localhost"
 Port = 8500
 CheckInterval = "10s"
 FailLimit = 3
 FailWaitTime = 10
+
+[Logging]
+EnableRemote = false
+File = "./device-virtual.log"
+
+[Writable]
+LogLevel = 'INFO'
 
 [Clients]
   [Clients.Data]
@@ -47,114 +55,40 @@ FailWaitTime = 10
   RemoveCmdArgs = ""
   ProfilesDir = "./res"
 
-[Logging]
-EnableRemote = false
-File = "./device-virtual.log"
-Level = "INFO"
-
 # Pre-define Devices
 [[DeviceList]]
   Name = "Random-Boolean-Generator01"
   Profile = "Random-Boolean-Generator"
   Description = "Example of Device Virtual"
   Labels = [ "device-virtual-example" ]
-  [DeviceList.Addressable]
-    Address = "device-virtual-bool-01"
-    Protocol = "OTHER"
+  [DeviceList.Protocols]
+    [DeviceList.Protocols.other]
+      Address = "device-virtual-bool-01"
+      Port = "300"
 [[DeviceList]]
   Name = "Random-Integer-Generator01"
   Profile = "Random-Integer-Generator"
   Description = "Example of Device Virtual"
   Labels = [ "device-virtual-example" ]
-  [DeviceList.Addressable]
-    Address = "device-virtual-int-01"
-    Protocol = "OTHER"
+  [DeviceList.Protocols]
+    [DeviceList.Protocols.other]
+      Address = "device-virtual-int-01"
+      Protocol = "300"
 [[DeviceList]]
   Name = "Random-UnsignedInteger-Generator01"
   Profile = "Random-UnsignedInteger-Generator"
   Description = "Example of Device Virtual"
   Labels = [ "device-virtual-example" ]
-  [DeviceList.Addressable]
-    Address = "device-virtual-uint-01"
-    Protocol = "OTHER"
+  [DeviceList.Protocols]
+    [DeviceList.Protocols.other]
+      Address = "device-virtual-uint-01"
+      Protocol = "300"
 [[DeviceList]]
   Name = "Random-Float-Generator01"
   Profile = "Random-Float-Generator"
   Description = "Example of Device Virtual"
   Labels = [ "device-virtual-example" ]
-  [DeviceList.Addressable]
-    Address = "device-virtual-float-01"
-    Protocol = "OTHER"
-
-
-# Pre-define Schedule Configuration
-[[Schedules]]
-Name = "5sec-schedule"
-Frequency = "PT5S"
-
-[[ScheduleEvents]]
-Name = "readValue_bool"
-Schedule = "5sec-schedule"
-  [ScheduleEvents.Addressable]
-  HTTPMethod = "GET"
-  Path = "/api/v1/device/name/Random-Boolean-Generator01/RandomValue_Bool"
-[[ScheduleEvents]]
-Name = "readValue_int8"
-Schedule = "5sec-schedule"
-  [ScheduleEvents.Addressable]
-  HTTPMethod = "GET"
-  Path = "/api/v1/device/name/Random-Integer-Generator01/RandomValue_Int8"
-[[ScheduleEvents]]
-Name = "readValue_int16"
-Schedule = "5sec-schedule"
-  [ScheduleEvents.Addressable]
-  HTTPMethod = "GET"
-  Path = "/api/v1/device/name/Random-Integer-Generator01/RandomValue_Int16"
-[[ScheduleEvents]]
-Name = "readValue_int32"
-Schedule = "5sec-schedule"
-  [ScheduleEvents.Addressable]
-  HTTPMethod = "GET"
-  Path = "/api/v1/device/name/Random-Integer-Generator01/RandomValue_Int32"
-[[ScheduleEvents]]
-Name = "readValue_int64"
-Schedule = "5sec-schedule"
-  [ScheduleEvents.Addressable]
-  HTTPMethod = "GET"
-  Path = "/api/v1/device/name/Random-Integer-Generator01/RandomValue_Int64"
-[[ScheduleEvents]]
-Name = "readValue_uint8"
-Schedule = "5sec-schedule"
-  [ScheduleEvents.Addressable]
-  HTTPMethod = "GET"
-  Path = "/api/v1/device/name/Random-UnsignedInteger-Generator01/RandomValue_Uint8"
-[[ScheduleEvents]]
-Name = "readValue_uint16"
-Schedule = "5sec-schedule"
-  [ScheduleEvents.Addressable]
-  HTTPMethod = "GET"
-  Path = "/api/v1/device/name/Random-UnsignedInteger-Generator01/RandomValue_Uint16"
-[[ScheduleEvents]]
-Name = "readValue_uint32"
-Schedule = "5sec-schedule"
-  [ScheduleEvents.Addressable]
-  HTTPMethod = "GET"
-  Path = "/api/v1/device/name/Random-UnsignedInteger-Generator01/RandomValue_Uint32"
-[[ScheduleEvents]]
-Name = "readValue_uint64"
-Schedule = "5sec-schedule"
-  [ScheduleEvents.Addressable]
-  HTTPMethod = "GET"
-  Path = "/api/v1/device/name/Random-UnsignedInteger-Generator01/RandomValue_Uint64"
-[[ScheduleEvents]]
-Name = "readValue_float32"
-Schedule = "5sec-schedule"
-  [ScheduleEvents.Addressable]
-  HTTPMethod = "GET"
-  Path = "/api/v1/device/name/Random-Float-Generator01/RandomValue_Float32"
-[[ScheduleEvents]]
-Name = "readValue_float64"
-Schedule = "5sec-schedule"
-  [ScheduleEvents.Addressable]
-  HTTPMethod = "GET"
-  Path = "/api/v1/device/name/Random-Float-Generator01/RandomValue_Float64"
+  [DeviceList.Protocols]
+    [DeviceList.Protocols.other]
+      Address = "device-virtual-float-01"
+      Protocol = "300"

--- a/cmd/res/device.virtual.bool.yaml
+++ b/cmd/res/device.virtual.bool.yaml
@@ -19,7 +19,7 @@ deviceResources:
   description: "Generate random boolean value"
   properties:
     value:
-      { type: "Bool", readWrite: "R", minimum: "false", maximum: "true", defaultValue: "true" }
+      { type: "Bool", readWrite: "R", defaultValue: "true" }
     units:
       { type: "String", readWrite: "R", defaultValue: "random bool value" }
 

--- a/cmd/res/device.virtual.float.yaml
+++ b/cmd/res/device.virtual.float.yaml
@@ -19,17 +19,9 @@ deviceResources:
   description: "Generate random float32 value"
   properties:
     value:
-      { type: "Float32", readWrite: "R", minimum: "0", maximum: "100", defaultValue: "3.14159" }
+      { type: "Float32", readWrite: "R", defaultValue: "0" }
     units:
       { type: "String", readWrite: "R", defaultValue: "random float32 value" }
--
-  name: "RandomValue_Float64"
-  description: "Generate random float64 value"
-  properties:
-    value:
-      { type: "Float64", readWrite: "R", minimum: "0", maximum: "100", defaultValue: "3.14159265359" }
-    units:
-      { type: "String", readWrite: "R", defaultValue: "random float64 value" }
 
 resources:
 -
@@ -39,13 +31,6 @@ resources:
   set:
     - { operation: "set", object: "RandomValue_Float32", property: "value", parameter: "RandomValue_Float32", resource: "RandomValue_Float32" }
     - { operation: "set", object: "Enable_Randomization", property: "value", parameter: "Enable_Randomization", resource: "RandomValue_Float32" }
--
-  name: "RandomValue_Float64"
-  get:
-    - { operation: "get", object: "RandomValue_Float64", property: "value", parameter: "RandomValue_Float64" }
-  set:
-    - { operation: "set", object: "RandomValue_Float64", property: "value", parameter: "RandomValue_Float64", resource: "RandomValue_Float64" }
-    - { operation: "set", object: "Enable_Randomization", property: "value", parameter: "Enable_Randomization", resource: "RandomValue_Float64" }
 
 commands:
 -
@@ -64,29 +49,6 @@ commands:
   put:
     path: "/api/v1/device/{deviceId}/RandomValue_Float32"
     parameterNames: ["RandomValue_Float32","Enable_Randomization"]
-    responses:
-      -
-        code: "200"
-        description: ""
-      -
-        code: "503"
-        description: "service unavailable"
--
-  name: "RandomValue_Float64"
-  get:
-    path: "/api/v1/device/{deviceId}/RandomValue_Float64"
-    responses:
-      -
-        code: "200"
-        description: ""
-        expectedValues: ["RandomValue_Float64"]
-      -
-        code: "503"
-        description: "service unavailable"
-        expectedValues: []
-  put:
-    path: "/api/v1/device/{deviceId}/RandomValue_Float64"
-    parameterNames: ["RandomValue_Float64","Enable_Randomization"]
     responses:
       -
         code: "200"

--- a/cmd/res/device.virtual.int.yaml
+++ b/cmd/res/device.virtual.int.yaml
@@ -19,7 +19,7 @@ deviceResources:
   description: "Generate random int8 value"
   properties:
     value:
-      { type: "Int8", readWrite: "R", minimum: "-100", maximum: "100", defaultValue: "0" }
+      { type: "Int8", readWrite: "R", defaultValue: "0" }
     units:
       { type: "String", readWrite: "R", defaultValue: "random int8 value" }
 -
@@ -27,7 +27,7 @@ deviceResources:
   description: "Generate random int16 value"
   properties:
     value:
-      { type: "Int16", readWrite: "R", minimum: "-100", maximum: "100", defaultValue: "0" }
+      { type: "Int16", readWrite: "R", defaultValue: "0" }
     units:
       { type: "String", readWrite: "R", defaultValue: "random int16 value" }
 -
@@ -35,17 +35,9 @@ deviceResources:
   description: "Generate random int32 value"
   properties:
     value:
-      { type: "Int32", readWrite: "R", minimum: "-100", maximum: "100", defaultValue: "0" }
+      { type: "Int32", readWrite: "R", defaultValue: "0" }
     units:
       { type: "String", readWrite: "R", defaultValue: "random int32 value" }
--
-  name: "RandomValue_Int64"
-  description: "Generate random int64 value"
-  properties:
-    value:
-      { type: "Int64", readWrite: "R", minimum: "-100", maximum: "100", defaultValue: "0" }
-    units:
-      { type: "String", readWrite: "R", defaultValue: "random int64 value" }
 
 resources:
 -
@@ -69,14 +61,6 @@ resources:
   set:
   - { operation: "set", object: "RandomValue_Int32", property: "value", parameter: "RandomValue_Int32", resource: "RandomValue_Int32" }
   - { operation: "set", object: "Enable_Randomization", property: "value", parameter: "Enable_Randomization", resource: "RandomValue_Int32" }
--
-  name: "RandomValue_Int64"
-  get:
-    - { operation: "get", object: "RandomValue_Int64", property: "value", parameter: "RandomValue_Int64" }
-  set:
-  - { operation: "set", object: "RandomValue_Int64", property: "value", parameter: "RandomValue_Int64", resource: "RandomValue_Int64" }
-  - { operation: "set", object: "Enable_Randomization", property: "value", parameter: "Enable_Randomization", resource: "RandomValue_Int64" }
-
 
 commands:
 -
@@ -141,29 +125,6 @@ commands:
   put:
     path: "/api/v1/device/{deviceId}/RandomValue_Int32"
     parameterNames: ["RandomValue_Int32","Enable_Randomization"]
-    responses:
-      -
-        code: "200"
-        description: ""
-      -
-        code: "503"
-        description: "service unavailable"
--
-  name: "RandomValue_Int64"
-  get:
-    path: "/api/v1/device/{deviceId}/RandomValue_Int64"
-    responses:
-      -
-        code: "200"
-        description: ""
-        expectedValues: ["RandomValue_Int64"]
-      -
-        code: "503"
-        description: "service unavailable"
-        expectedValues: []
-  put:
-    path: "/api/v1/device/{deviceId}/RandomValue_Int64"
-    parameterNames: ["RandomValue_Int64","Enable_Randomization"]
     responses:
       -
         code: "200"

--- a/cmd/res/device.virtual.uint.yaml
+++ b/cmd/res/device.virtual.uint.yaml
@@ -19,7 +19,7 @@ deviceResources:
   description: "Generate random uint8 value"
   properties:
     value:
-      { type: "Uint8", readWrite: "R", minimum: "0", maximum: "100", defaultValue: "0" }
+      { type: "Uint8", readWrite: "R", defaultValue: "0" }
     units:
       { type: "String", readWrite: "R", defaultValue: "random uint8 value" }
 -
@@ -27,7 +27,7 @@ deviceResources:
   description: "Generate random uint16 value"
   properties:
     value:
-      { type: "Uint16", readWrite: "R", minimum: "0", maximum: "100", defaultValue: "0" }
+      { type: "Uint16", readWrite: "R", defaultValue: "0" }
     units:
       { type: "String", readWrite: "R", defaultValue: "random uint16 value" }
 -
@@ -35,17 +35,9 @@ deviceResources:
   description: "Generate random uint32 value"
   properties:
     value:
-      { type: "Uint32", readWrite: "R", minimum: "0", maximum: "100", defaultValue: "0" }
+      { type: "Uint32", readWrite: "R", defaultValue: "0" }
     units:
       { type: "String", readWrite: "R", defaultValue: "random uint32 value" }
--
-  name: "RandomValue_Uint64"
-  description: "Generate random uint64 value"
-  properties:
-    value:
-      { type: "Uint64", readWrite: "R", minimum: "0", maximum: "100", defaultValue: "0" }
-    units:
-      { type: "String", readWrite: "R", defaultValue: "random uint64 value" }
 
 resources:
 -
@@ -69,13 +61,6 @@ resources:
   set:
   - { operation: "set", object: "RandomValue_Uint32", property: "value", parameter: "RandomValue_Uint32", resource: "RandomValue_Uint32" }
   - { operation: "set", object: "Enable_Randomization", property: "value", parameter: "Enable_Randomization", resource: "RandomValue_Uint32" }
--
-  name: "RandomValue_Uint64"
-  get:
-  - { operation: "get", object: "RandomValue_Uint64", property: "value", parameter: "RandomValue_Uint64" }
-  set:
-  - { operation: "set", object: "RandomValue_Uint64", property: "value", parameter: "RandomValue_Uint64", resource: "RandomValue_Uint64" }
-  - { operation: "set", object: "Enable_Randomization", property: "value", parameter: "Enable_Randomization", resource: "RandomValue_Uint64" }
 
 commands:
 -
@@ -140,29 +125,6 @@ commands:
   put:
     path: "/api/v1/device/{deviceId}/RandomValue_Uint32"
     parameterNames: ["RandomValue_Uint32","Enable_Randomization"]
-    responses:
-      -
-        code: "200"
-        description: ""
-      -
-        code: "503"
-        description: "service unavailable"
--
-  name: "RandomValue_Uint64"
-  get:
-    path: "/api/v1/device/{deviceId}/RandomValue_Uint64"
-    responses:
-      -
-        code: "200"
-        description: ""
-        expectedValues: ["RandomValue_Uint64"]
-      -
-        code: "503"
-        description: "service unavailable"
-        expectedValues: []
-  put:
-    path: "/api/v1/device/{deviceId}/RandomValue_Uint64"
-    parameterNames: ["RandomValue_Uint64","Enable_Randomization"]
     responses:
       -
         code: "200"

--- a/cmd/res/docker/configuration.toml
+++ b/cmd/res/docker/configuration.toml
@@ -10,11 +10,19 @@ EnableAsyncReadings = true
 AsyncBufferSize = 16
 
 [Registry]
+Type = "consul"
 Host = "edgex-core-consul"
 Port = 8500
 CheckInterval = "10s"
 FailLimit = 3
 FailWaitTime = 10
+
+[Logging]
+EnableRemote = false
+File = "./device-virtual.log"
+
+[Writable]
+LogLevel = 'INFO'
 
 [Clients]
   [Clients.Data]
@@ -47,113 +55,40 @@ FailWaitTime = 10
   RemoveCmdArgs = ""
   ProfilesDir = "./res"
 
-[Logging]
-EnableRemote = true
-File = "./device-virtual.log"
-Level = "INFO"
-
 # Pre-define Devices
 [[DeviceList]]
   Name = "Random-Boolean-Generator01"
   Profile = "Random-Boolean-Generator"
   Description = "Example of Device Virtual"
   Labels = [ "device-virtual-example" ]
-  [DeviceList.Addressable]
-    Address = "device-virtual-bool-01"
-    Protocol = "OTHER"
+  [DeviceList.Protocols]
+    [DeviceList.Protocols.other]
+      Address = "device-virtual-bool-01"
+      Port = "300"
 [[DeviceList]]
   Name = "Random-Integer-Generator01"
   Profile = "Random-Integer-Generator"
   Description = "Example of Device Virtual"
   Labels = [ "device-virtual-example" ]
-  [DeviceList.Addressable]
-    Address = "device-virtual-int-01"
-    Protocol = "OTHER"
+  [DeviceList.Protocols]
+    [DeviceList.Protocols.other]
+      Address = "device-virtual-int-01"
+      Protocol = "300"
 [[DeviceList]]
   Name = "Random-UnsignedInteger-Generator01"
   Profile = "Random-UnsignedInteger-Generator"
   Description = "Example of Device Virtual"
   Labels = [ "device-virtual-example" ]
-  [DeviceList.Addressable]
-    Address = "device-virtual-uint-01"
-    Protocol = "OTHER"
+  [DeviceList.Protocols]
+    [DeviceList.Protocols.other]
+      Address = "device-virtual-uint-01"
+      Protocol = "300"
 [[DeviceList]]
   Name = "Random-Float-Generator01"
   Profile = "Random-Float-Generator"
   Description = "Example of Device Virtual"
   Labels = [ "device-virtual-example" ]
-  [DeviceList.Addressable]
-    Address = "device-virtual-float-01"
-    Protocol = "OTHER"
-
-# Pre-define Schedule Configuration
-[[Schedules]]
-Name = "5sec-schedule"
-Frequency = "PT5S"
-
-[[ScheduleEvents]]
-Name = "readValue_bool"
-Schedule = "5sec-schedule"
-  [ScheduleEvents.Addressable]
-  HTTPMethod = "GET"
-  Path = "/api/v1/device/name/Random-Boolean-Generator01/RandomValue_Bool"
-[[ScheduleEvents]]
-Name = "readValue_int8"
-Schedule = "5sec-schedule"
-  [ScheduleEvents.Addressable]
-  HTTPMethod = "GET"
-  Path = "/api/v1/device/name/Random-Integer-Generator01/RandomValue_Int8"
-[[ScheduleEvents]]
-Name = "readValue_int16"
-Schedule = "5sec-schedule"
-  [ScheduleEvents.Addressable]
-  HTTPMethod = "GET"
-  Path = "/api/v1/device/name/Random-Integer-Generator01/RandomValue_Int16"
-[[ScheduleEvents]]
-Name = "readValue_int32"
-Schedule = "5sec-schedule"
-  [ScheduleEvents.Addressable]
-  HTTPMethod = "GET"
-  Path = "/api/v1/device/name/Random-Integer-Generator01/RandomValue_Int32"
-[[ScheduleEvents]]
-Name = "readValue_int64"
-Schedule = "5sec-schedule"
-  [ScheduleEvents.Addressable]
-  HTTPMethod = "GET"
-  Path = "/api/v1/device/name/Random-Integer-Generator01/RandomValue_Int64"
-[[ScheduleEvents]]
-Name = "readValue_uint8"
-Schedule = "5sec-schedule"
-  [ScheduleEvents.Addressable]
-  HTTPMethod = "GET"
-  Path = "/api/v1/device/name/Random-UnsignedInteger-Generator01/RandomValue_Uint8"
-[[ScheduleEvents]]
-Name = "readValue_uint16"
-Schedule = "5sec-schedule"
-  [ScheduleEvents.Addressable]
-  HTTPMethod = "GET"
-  Path = "/api/v1/device/name/Random-UnsignedInteger-Generator01/RandomValue_Uint16"
-[[ScheduleEvents]]
-Name = "readValue_uint32"
-Schedule = "5sec-schedule"
-  [ScheduleEvents.Addressable]
-  HTTPMethod = "GET"
-  Path = "/api/v1/device/name/Random-UnsignedInteger-Generator01/RandomValue_Uint32"
-[[ScheduleEvents]]
-Name = "readValue_uint64"
-Schedule = "5sec-schedule"
-  [ScheduleEvents.Addressable]
-  HTTPMethod = "GET"
-  Path = "/api/v1/device/name/Random-UnsignedInteger-Generator01/RandomValue_Uint64"
-[[ScheduleEvents]]
-Name = "readValue_float32"
-Schedule = "5sec-schedule"
-  [ScheduleEvents.Addressable]
-  HTTPMethod = "GET"
-  Path = "/api/v1/device/name/Random-Float-Generator01/RandomValue_Float32"
-[[ScheduleEvents]]
-Name = "readValue_float64"
-Schedule = "5sec-schedule"
-  [ScheduleEvents.Addressable]
-  HTTPMethod = "GET"
-  Path = "/api/v1/device/name/Random-Float-Generator01/RandomValue_Float64"
+  [DeviceList.Protocols]
+    [DeviceList.Protocols.other]
+      Address = "device-virtual-float-01"
+      Protocol = "300"

--- a/cmd/res/example/device.virtual.bool.yaml
+++ b/cmd/res/example/device.virtual.bool.yaml
@@ -1,0 +1,58 @@
+name: "Random-Boolean-Generator"
+manufacturer: "IOTech"
+model: "Device-Virtual-01"
+labels:
+- "device-virtual-example"
+description: "Example of Device-Virtual"
+
+deviceResources:
+-
+  name: "Enable_Randomization"
+  description: "used to decide whether to re-generate a random value"
+  properties:
+    value:
+      { type: "Bool", readWrite: "W", defaultValue: "true" }
+    units:
+      { type: "String", readWrite: "R", defaultValue: "Random" }
+-
+  name: "RandomValue_Bool"
+  description: "Generate random boolean value"
+  properties:
+    value:
+      { type: "Bool", readWrite: "R", defaultValue: "true" }
+    units:
+      { type: "String", readWrite: "R", defaultValue: "random bool value" }
+
+resources:
+-
+  name: "RandomValue_Bool"
+  get:
+    - { operation: "get", object: "RandomValue_Bool", property: "value", parameter: "RandomValue_Bool" }
+  set:
+    - { operation: "set", object: "Enable_Randomization", property: "value", parameter: "Enable_Randomization", resource: "Enable_Randomization" }
+    - { operation: "set", object: "RandomValue_Bool", property: "value", parameter: "RandomValue_Bool", resource: "RandomValue_Bool" }
+
+commands:
+-
+  name: "RandomValue_Bool"
+  get:
+    path: "/api/v1/device/{deviceId}/RandomValue_Bool"
+    responses:
+      -
+        code: "200"
+        description: ""
+        expectedValues: ["RandomValue_Bool"]
+      -
+        code: "503"
+        description: "service unavailable"
+        expectedValues: []
+  put:
+    path: "/api/v1/device/{deviceId}/RandomValue_Bool"
+    parameterNames: ["RandomValue_Bool","Enable_Randomization"]
+    responses:
+      -
+        code: "200"
+        description: ""
+      -
+        code: "503"
+        description: "service unavailable"

--- a/cmd/res/example/device.virtual.float.yaml
+++ b/cmd/res/example/device.virtual.float.yaml
@@ -1,0 +1,96 @@
+name: "Random-Float-Generator"
+manufacturer: "IOTech"
+model: "Device-Virtual-01"
+labels:
+- "device-virtual-example"
+description: "Example of Device-Virtual"
+
+deviceResources:
+-
+  name: "Enable_Randomization"
+  description: "used to decide whether to re-generate a random value"
+  properties:
+    value:
+      { type: "Bool", readWrite: "W", defaultValue: "true" }
+    units:
+      { type: "String", readWrite: "R", defaultValue: "Random" }
+-
+  name: "RandomValue_Float32"
+  description: "Generate random float32 value"
+  properties:
+    value:
+      { type: "Float32", readWrite: "R", defaultValue: "0" }
+    units:
+      { type: "String", readWrite: "R", defaultValue: "random float32 value" }
+-
+  name: "RandomValue_Float64"
+  description: "Generate random float64 value"
+  properties:
+    value:
+      { type: "Float64", readWrite: "R", defaultValue: "0" }
+    units:
+      { type: "String", readWrite: "R", defaultValue: "random float64 value" }
+
+resources:
+-
+  name: "RandomValue_Float32"
+  get:
+    - { operation: "get", object: "RandomValue_Float32", property: "value", parameter: "RandomValue_Float32" }
+  set:
+    - { operation: "set", object: "RandomValue_Float32", property: "value", parameter: "RandomValue_Float32", resource: "RandomValue_Float32" }
+    - { operation: "set", object: "Enable_Randomization", property: "value", parameter: "Enable_Randomization", resource: "RandomValue_Float32" }
+-
+  name: "RandomValue_Float64"
+  get:
+    - { operation: "get", object: "RandomValue_Float64", property: "value", parameter: "RandomValue_Float64" }
+  set:
+    - { operation: "set", object: "RandomValue_Float64", property: "value", parameter: "RandomValue_Float64", resource: "RandomValue_Float64" }
+    - { operation: "set", object: "Enable_Randomization", property: "value", parameter: "Enable_Randomization", resource: "RandomValue_Float64" }
+
+commands:
+-
+  name: "RandomValue_Float32"
+  get:
+    path: "/api/v1/device/{deviceId}/RandomValue_Float32"
+    responses:
+      -
+        code: "200"
+        description: ""
+        expectedValues: ["RandomValue_Float32"]
+      -
+        code: "503"
+        description: "service unavailable"
+        expectedValues: []
+  put:
+    path: "/api/v1/device/{deviceId}/RandomValue_Float32"
+    parameterNames: ["RandomValue_Float32","Enable_Randomization"]
+    responses:
+      -
+        code: "200"
+        description: ""
+      -
+        code: "503"
+        description: "service unavailable"
+-
+  name: "RandomValue_Float64"
+  get:
+    path: "/api/v1/device/{deviceId}/RandomValue_Float64"
+    responses:
+      -
+        code: "200"
+        description: ""
+        expectedValues: ["RandomValue_Float64"]
+      -
+        code: "503"
+        description: "service unavailable"
+        expectedValues: []
+  put:
+    path: "/api/v1/device/{deviceId}/RandomValue_Float64"
+    parameterNames: ["RandomValue_Float64","Enable_Randomization"]
+    responses:
+      -
+        code: "200"
+        description: ""
+      -
+        code: "503"
+        description: "service unavailable"

--- a/cmd/res/example/device.virtual.int.yaml
+++ b/cmd/res/example/device.virtual.int.yaml
@@ -1,0 +1,173 @@
+name: "Random-Integer-Generator"
+manufacturer: "IOTech"
+model: "Device-Virtual-01"
+labels:
+- "device-virtual-example"
+description: "Example of Device-Virtual"
+
+deviceResources:
+-
+  name: "Enable_Randomization"
+  description: "used to decide whether to re-generate a random value"
+  properties:
+    value:
+      { type: "Bool", readWrite: "W", defaultValue: "true" }
+    units:
+      { type: "String", readWrite: "R", defaultValue: "Random" }
+-
+  name: "RandomValue_Int8"
+  description: "Generate random int8 value"
+  properties:
+    value:
+      { type: "Int8", readWrite: "R", defaultValue: "0" }
+    units:
+      { type: "String", readWrite: "R", defaultValue: "random int8 value" }
+-
+  name: "RandomValue_Int16"
+  description: "Generate random int16 value"
+  properties:
+    value:
+      { type: "Int16", readWrite: "R", defaultValue: "0" }
+    units:
+      { type: "String", readWrite: "R", defaultValue: "random int16 value" }
+-
+  name: "RandomValue_Int32"
+  description: "Generate random int32 value"
+  properties:
+    value:
+      { type: "Int32", readWrite: "R", defaultValue: "0" }
+    units:
+      { type: "String", readWrite: "R", defaultValue: "random int32 value" }
+-
+  name: "RandomValue_Int64"
+  description: "Generate random int64 value"
+  properties:
+    value:
+      { type: "Int64", readWrite: "R", defaultValue: "0" }
+    units:
+      { type: "String", readWrite: "R", defaultValue: "random int64 value" }
+
+resources:
+-
+  name: "RandomValue_Int8"
+  get:
+  - { operation: "get", object: "RandomValue_Int8", property: "value", parameter: "RandomValue_Int8" }
+  set:
+  - { operation: "set", object: "RandomValue_Int8", property: "value", parameter: "RandomValue_Int8", resource: "RandomValue_Int8" }
+  - { operation: "set", object: "Enable_Randomization", property: "value", parameter: "Enable_Randomization", resource: "RandomValue_Int8" }
+-
+  name: "RandomValue_Int16"
+  get:
+  - { operation: "get", object: "RandomValue_Int16", property: "value", parameter: "RandomValue_Int16" }
+  set:
+  - { operation: "set", object: "RandomValue_Int16", property: "value", parameter: "RandomValue_Int16", resource: "RandomValue_Int16" }
+  - { operation: "set", object: "Enable_Randomization", property: "value", parameter: "Enable_Randomization", resource: "RandomValue_Int16" }
+-
+  name: "RandomValue_Int32"
+  get:
+  - { operation: "get", object: "RandomValue_Int32", property: "value", parameter: "RandomValue_Int32" }
+  set:
+  - { operation: "set", object: "RandomValue_Int32", property: "value", parameter: "RandomValue_Int32", resource: "RandomValue_Int32" }
+  - { operation: "set", object: "Enable_Randomization", property: "value", parameter: "Enable_Randomization", resource: "RandomValue_Int32" }
+-
+  name: "RandomValue_Int64"
+  get:
+    - { operation: "get", object: "RandomValue_Int64", property: "value", parameter: "RandomValue_Int64" }
+  set:
+  - { operation: "set", object: "RandomValue_Int64", property: "value", parameter: "RandomValue_Int64", resource: "RandomValue_Int64" }
+  - { operation: "set", object: "Enable_Randomization", property: "value", parameter: "Enable_Randomization", resource: "RandomValue_Int64" }
+
+
+commands:
+-
+  name: "RandomValue_Int8"
+  get:
+    path: "/api/v1/device/{deviceId}/RandomValue_Int8"
+    responses:
+    -
+      code: "200"
+      description: ""
+      expectedValues: ["RandomValue_Int8"]
+    -
+      code: "503"
+      description: "service unavailable"
+      expectedValues: []
+  put:
+    path: "/api/v1/device/{deviceId}/RandomValue_Int8"
+    parameterNames: ["RandomValue_Int8","Enable_Randomization"]
+    responses:
+    -
+      code: "200"
+      description: ""
+    -
+      code: "503"
+      description: "service unavailable"
+-
+  name: "RandomValue_Int16"
+  get:
+    path: "/api/v1/device/{deviceId}/RandomValue_Int16"
+    responses:
+    -
+      code: "200"
+      description: ""
+      expectedValues: ["RandomValue_Int16"]
+    -
+      code: "503"
+      description: "service unavailable"
+      expectedValues: []
+  put:
+    path: "/api/v1/device/{deviceId}/RandomValue_Int16"
+    parameterNames: ["RandomValue_Int16","Enable_Randomization"]
+    responses:
+    -
+      code: "200"
+      description: ""
+    -
+      code: "503"
+      description: "service unavailable"
+-
+  name: "RandomValue_Int32"
+  get:
+    path: "/api/v1/device/{deviceId}/RandomValue_Int32"
+    responses:
+    -
+      code: "200"
+      description: ""
+      expectedValues: ["RandomValue_Int32"]
+    -
+      code: "503"
+      description: "service unavailable"
+      expectedValues: []
+  put:
+    path: "/api/v1/device/{deviceId}/RandomValue_Int32"
+    parameterNames: ["RandomValue_Int32","Enable_Randomization"]
+    responses:
+      -
+        code: "200"
+        description: ""
+      -
+        code: "503"
+        description: "service unavailable"
+-
+  name: "RandomValue_Int64"
+  get:
+    path: "/api/v1/device/{deviceId}/RandomValue_Int64"
+    responses:
+      -
+        code: "200"
+        description: ""
+        expectedValues: ["RandomValue_Int64"]
+      -
+        code: "503"
+        description: "service unavailable"
+        expectedValues: []
+  put:
+    path: "/api/v1/device/{deviceId}/RandomValue_Int64"
+    parameterNames: ["RandomValue_Int64","Enable_Randomization"]
+    responses:
+      -
+        code: "200"
+        description: ""
+      -
+        code: "503"
+        description: "service unavailable"

--- a/cmd/res/example/device.virtual.uint.yaml
+++ b/cmd/res/example/device.virtual.uint.yaml
@@ -1,0 +1,172 @@
+name: "Random-UnsignedInteger-Generator"
+manufacturer: "IOTech"
+model: "Device-Virtual-01"
+labels:
+- "device-virtual-example"
+description: "Example of Device-Virtual"
+
+deviceResources:
+-
+  name: "Enable_Randomization"
+  description: "used to decide whether to re-generate a random value"
+  properties:
+    value:
+      { type: "Bool", readWrite: "W", defaultValue: "true" }
+    units:
+      { type: "String", readWrite: "R", defaultValue: "Random" }
+-
+  name: "RandomValue_Uint8"
+  description: "Generate random uint8 value"
+  properties:
+    value:
+      { type: "Uint8", readWrite: "R", defaultValue: "0" }
+    units:
+      { type: "String", readWrite: "R", defaultValue: "random uint8 value" }
+-
+  name: "RandomValue_Uint16"
+  description: "Generate random uint16 value"
+  properties:
+    value:
+      { type: "Uint16", readWrite: "R", defaultValue: "0" }
+    units:
+      { type: "String", readWrite: "R", defaultValue: "random uint16 value" }
+-
+  name: "RandomValue_Uint32"
+  description: "Generate random uint32 value"
+  properties:
+    value:
+      { type: "Uint32", readWrite: "R", defaultValue: "0" }
+    units:
+      { type: "String", readWrite: "R", defaultValue: "random uint32 value" }
+-
+  name: "RandomValue_Uint64"
+  description: "Generate random uint64 value"
+  properties:
+    value:
+      { type: "Uint64", readWrite: "R", defaultValue: "0" }
+    units:
+      { type: "String", readWrite: "R", defaultValue: "random uint64 value" }
+
+resources:
+-
+  name: "RandomValue_Uint8"
+  get:
+  - { operation: "get", object: "RandomValue_Uint8", property: "value", parameter: "RandomValue_Uint8" }
+  set:
+  - { operation: "set", object: "RandomValue_Uint8", property: "value", parameter: "RandomValue_Uint8", resource: "RandomValue_Uint8" }
+  - { operation: "set", object: "Enable_Randomization", property: "value", parameter: "Enable_Randomization", resource: "RandomValue_Uint8" }
+-
+  name: "RandomValue_Uint16"
+  get:
+  - { operation: "get", object: "RandomValue_Uint16", property: "value", parameter: "RandomValue_Uint16" }
+  set:
+  - { operation: "set", object: "RandomValue_Uint16", property: "value", parameter: "RandomValue_Uint16", resource: "RandomValue_Uint16" }
+  - { operation: "set", object: "Enable_Randomization", property: "value", parameter: "Enable_Randomization", resource: "RandomValue_Uint16" }
+-
+  name: "RandomValue_Uint32"
+  get:
+  - { operation: "get", object: "RandomValue_Uint32", property: "value", parameter: "RandomValue_Uint32" }
+  set:
+  - { operation: "set", object: "RandomValue_Uint32", property: "value", parameter: "RandomValue_Uint32", resource: "RandomValue_Uint32" }
+  - { operation: "set", object: "Enable_Randomization", property: "value", parameter: "Enable_Randomization", resource: "RandomValue_Uint32" }
+-
+  name: "RandomValue_Uint64"
+  get:
+  - { operation: "get", object: "RandomValue_Uint64", property: "value", parameter: "RandomValue_Uint64" }
+  set:
+  - { operation: "set", object: "RandomValue_Uint64", property: "value", parameter: "RandomValue_Uint64", resource: "RandomValue_Uint64" }
+  - { operation: "set", object: "Enable_Randomization", property: "value", parameter: "Enable_Randomization", resource: "RandomValue_Uint64" }
+
+commands:
+-
+  name: "RandomValue_Uint8"
+  get:
+    path: "/api/v1/device/{deviceId}/RandomValue_Uint8"
+    responses:
+    -
+      code: "200"
+      description: ""
+      expectedValues: ["RandomValue_Uint8"]
+    -
+      code: "503"
+      description: "service unavailable"
+      expectedValues: []
+  put:
+    path: "/api/v1/device/{deviceId}/RandomValue_Uint8"
+    parameterNames: ["RandomValue_Uint8","Enable_Randomization"]
+    responses:
+    -
+      code: "200"
+      description: ""
+    -
+      code: "503"
+      description: "service unavailable"
+-
+  name: "RandomValue_Uint16"
+  get:
+    path: "/api/v1/device/{deviceId}/RandomValue_Uint16"
+    responses:
+    -
+      code: "200"
+      description: ""
+      expectedValues: ["RandomValue_Uint16"]
+    -
+      code: "503"
+      description: "service unavailable"
+      expectedValues: []
+  put:
+    path: "/api/v1/device/{deviceId}/RandomValue_Uint16"
+    parameterNames: ["RandomValue_Uint16","Enable_Randomization"]
+    responses:
+    -
+      code: "200"
+      description: ""
+    -
+      code: "503"
+      description: "service unavailable"
+-
+  name: "RandomValue_Uint32"
+  get:
+    path: "/api/v1/device/{deviceId}/RandomValue_Uint32"
+    responses:
+    -
+      code: "200"
+      description: ""
+      expectedValues: ["RandomValue_Uint32"]
+    -
+      code: "503"
+      description: "service unavailable"
+      expectedValues: []
+  put:
+    path: "/api/v1/device/{deviceId}/RandomValue_Uint32"
+    parameterNames: ["RandomValue_Uint32","Enable_Randomization"]
+    responses:
+      -
+        code: "200"
+        description: ""
+      -
+        code: "503"
+        description: "service unavailable"
+-
+  name: "RandomValue_Uint64"
+  get:
+    path: "/api/v1/device/{deviceId}/RandomValue_Uint64"
+    responses:
+      -
+        code: "200"
+        description: ""
+        expectedValues: ["RandomValue_Uint64"]
+      -
+        code: "503"
+        description: "service unavailable"
+        expectedValues: []
+  put:
+    path: "/api/v1/device/{deviceId}/RandomValue_Uint64"
+    parameterNames: ["RandomValue_Uint64","Enable_Randomization"]
+    responses:
+      -
+        code: "200"
+        description: ""
+      -
+        code: "503"
+        description: "service unavailable"

--- a/driver/resourcebool.go
+++ b/driver/resourcebool.go
@@ -1,0 +1,65 @@
+package driver
+
+import (
+	"fmt"
+	"math/rand"
+	"strconv"
+	"time"
+
+	dsModels "github.com/edgexfoundry/device-sdk-go/pkg/models"
+	"github.com/edgexfoundry/go-mod-core-contracts/models"
+)
+
+type resourceBool struct{}
+
+func (rb *resourceBool) value(db *db, ro *models.ResourceOperation, deviceName, deviceResourceName string) (*dsModels.CommandValue, error) {
+	result := &dsModels.CommandValue{}
+
+	enableRandomization, currentValue, _, err := db.getVirtualResourceData(deviceName, deviceResourceName)
+	if err != nil {
+		return result, err
+	}
+
+	var newValueBool bool
+	if enableRandomization {
+		rand.Seed(time.Now().UnixNano())
+		newValueBool = rand.Int()%2 == 0
+	} else {
+		if newValueBool, err = strconv.ParseBool(currentValue); err != nil {
+			return result, err
+		}
+	}
+	now := time.Now().UnixNano() / int64(time.Millisecond)
+	if result, err = dsModels.NewBoolValue(ro, now, newValueBool); err != nil {
+		return result, err
+	}
+	if err := db.updateResourceValue(result.ValueToString(), deviceName, deviceResourceName); err != nil {
+		return result, err
+	}
+
+	return result, nil
+}
+
+func (rb *resourceBool) write(param *dsModels.CommandValue, deviceName string, db *db) error {
+	switch param.RO.Object {
+	case deviceResourceEnableRandomization:
+		v, err := param.BoolValue()
+		if err != nil {
+			return fmt.Errorf("resourceBool.write: %v", err)
+		}
+		if err := db.exec(SQL_UPDATE_ENABLERANDOMIZATION, v, deviceName, deviceResourceBool); err != nil {
+			return fmt.Errorf("resourceBool.write: %v", err)
+		} else {
+			return nil
+		}
+	case deviceResourceBool:
+		if _, err := param.BoolValue(); err == nil {
+			return db.exec(SQL_UPDATE_VALUE, param.ValueToString(), deviceName, param.RO.Resource)
+		} else {
+			return fmt.Errorf("resourceBool.write: %v", err)
+		}
+	default:
+		return fmt.Errorf("resourceBool.write: unknown device resource: %s", param.RO.Object)
+	}
+
+}

--- a/driver/resourcefloat.go
+++ b/driver/resourcefloat.go
@@ -1,0 +1,134 @@
+package driver
+
+import (
+	"fmt"
+	"math/rand"
+	"strconv"
+	"time"
+
+	dsModels "github.com/edgexfoundry/device-sdk-go/pkg/models"
+	"github.com/edgexfoundry/go-mod-core-contracts/models"
+)
+
+type resourceFloat struct{}
+
+func (rf *resourceFloat) value(db *db, ro *models.ResourceOperation, deviceName, deviceResourceName, minimum,
+	maximum string) (*dsModels.CommandValue, error) {
+
+	result := &dsModels.CommandValue{}
+
+	enableRandomization, currentValue, dataType, err := db.getVirtualResourceData(deviceName, deviceResourceName)
+	if err != nil {
+		return result, err
+	}
+
+	now := time.Now().UnixNano() / int64(time.Millisecond)
+	rand.Seed(time.Now().UnixNano())
+	signHelper := []float64{-1, 1}
+	var newValueFloat float64
+	var bitSize int
+	min, max, err := parseFloatMinimumMaximum(minimum, maximum, dataType)
+
+	switch dataType {
+	case typeFloat32:
+		bitSize = 32
+		if enableRandomization {
+			if err == nil {
+				newValueFloat = randomFloat(min, max)
+			} else {
+				newValueFloat = float64(rand.Float32()) * signHelper[rand.Int()%2]
+			}
+		} else if newValueFloat, err = strconv.ParseFloat(currentValue, 32); err != nil {
+			return result, err
+		}
+		result, err = dsModels.NewFloat32Value(ro, now, float32(newValueFloat))
+	case typeFloat64:
+		bitSize = 64
+		if enableRandomization {
+			if err == nil {
+				newValueFloat = randomFloat(min, max)
+			} else {
+				newValueFloat = rand.Float64() * signHelper[rand.Int()%2]
+			}
+		} else if newValueFloat, err = strconv.ParseFloat(currentValue, 64); err != nil {
+			return result, err
+		}
+		result, err = dsModels.NewFloat64Value(ro, now, newValueFloat)
+	}
+
+	if err != nil {
+		return result, err
+	}
+	err = db.updateResourceValue(strconv.FormatFloat(newValueFloat, 'f', -1, bitSize), data.DeviceName, data.DeviceResourceName)
+	return result, err
+}
+
+func randomFloat(min, max float64) float64 {
+	rand.Seed(time.Now().UnixNano())
+	if max > 0 && min < 0 {
+		var negativePart float64
+		var positivePart float64
+		negativePart = rand.Float64() * min
+		positivePart = rand.Float64() * max
+		return negativePart + positivePart
+	} else {
+		return rand.Float64()*(max-min) + min
+	}
+}
+
+func parseStrToFloat(str string, bitSize int) (float64, error) {
+	if f, err := strconv.ParseFloat(str, bitSize); err != nil {
+		return f, err
+	} else {
+		return f, nil
+	}
+}
+
+func parseFloatMinimumMaximum(minimum, maximum, dataType string) (float64, float64, error) {
+	var err, err1, err2 error
+	var min, max float64
+	switch dataType {
+	case typeFloat32:
+		min, err1 = parseStrToFloat(minimum, 32)
+		max, err2 = parseStrToFloat(maximum, 32)
+		if max <= min || err1 != nil || err2 != nil {
+			err = fmt.Errorf("minimum:%s maximum:%s not in valid range, use default value", minimum, maximum)
+		}
+	case typeFloat64:
+		min, err1 = parseStrToFloat(minimum, 64)
+		max, err2 = parseStrToFloat(maximum, 64)
+		if max <= min || err1 != nil || err2 != nil {
+			err = fmt.Errorf("minimum:%s maximum:%s not in valid range, use default value", minimum, maximum)
+		}
+	}
+	return min, max, err
+}
+
+func (rf *resourceFloat) write(param *dsModels.CommandValue, deviceName string, db *db) error {
+	switch param.RO.Object {
+	case deviceResourceEnableRandomization:
+		v, err := param.BoolValue()
+		if err != nil {
+			return fmt.Errorf("resourceFloat.write: %v", err)
+		}
+		if err := db.exec(SQL_UPDATE_ENABLERANDOMIZATION, v, deviceName, param.RO.Resource); err != nil {
+			return fmt.Errorf("resourceFloat.write: %v", err)
+		} else {
+			return nil
+		}
+	case deviceResourceFloat32:
+		if v, err := param.Float32Value(); err == nil {
+			return db.exec(SQL_UPDATE_VALUE, strconv.FormatFloat(float64(v), 'f', -1, 32), deviceName, param.RO.Resource)
+		} else {
+			return err
+		}
+	case deviceResourceFloat64:
+		if v, err := param.Float64Value(); err == nil {
+			return db.exec(SQL_UPDATE_VALUE, strconv.FormatFloat(float64(v), 'f', -1, 64), deviceName, param.RO.Resource)
+		} else {
+			return err
+		}
+	default:
+		return fmt.Errorf("resourceFloat.write: unknown device resource: %s", param.RO.Object)
+	}
+}

--- a/driver/resourceint.go
+++ b/driver/resourceint.go
@@ -1,0 +1,179 @@
+package driver
+
+import (
+	"fmt"
+	"math"
+	"math/rand"
+	"strconv"
+	"time"
+
+	dsModels "github.com/edgexfoundry/device-sdk-go/pkg/models"
+	"github.com/edgexfoundry/go-mod-core-contracts/models"
+)
+
+type resourceInt struct{}
+
+func (ri *resourceInt) value(db *db, ro *models.ResourceOperation, deviceName, deviceResourceName, minimum,
+	maximum string) (*dsModels.CommandValue, error) {
+
+	result := &dsModels.CommandValue{}
+
+	enableRandomization, currentValue, dataType, err := db.getVirtualResourceData(deviceName, deviceResourceName)
+	if err != nil {
+		return result, err
+	}
+
+	now := time.Now().UnixNano() / int64(time.Millisecond)
+	rand.Seed(time.Now().UnixNano())
+	signHelper := []int64{-1, 1}
+	var newValueInt int64
+	min, max, err := parseIntMinimumMaximum(minimum, maximum, dataType)
+
+	switch dataType {
+	case typeInt8:
+		if enableRandomization {
+			newValueInt = randomInt(min, max)
+		} else if newValueInt, err = strconv.ParseInt(currentValue, 10, 8); err != nil {
+			return result, err
+		}
+		result, err = dsModels.NewInt8Value(ro, now, int8(newValueInt))
+	case typeInt16:
+		if enableRandomization {
+			newValueInt = randomInt(min, max)
+		} else if newValueInt, err = strconv.ParseInt(currentValue, 10, 16); err != nil {
+			return result, err
+		}
+		result, err = dsModels.NewInt16Value(ro, now, int16(newValueInt))
+	case typeInt32:
+		if enableRandomization {
+			if err == nil {
+				newValueInt = randomInt(min, max)
+			} else {
+				newValueInt = int64(rand.Int31()) * signHelper[rand.Int()%2]
+			}
+		} else if newValueInt, err = strconv.ParseInt(currentValue, 10, 32); err != nil {
+			return result, err
+		}
+		result, err = dsModels.NewInt32Value(ro, now, int32(newValueInt))
+	case typeInt64:
+		if enableRandomization {
+			if err == nil {
+				newValueInt = randomInt(min, max)
+			} else {
+				newValueInt = rand.Int63() * signHelper[rand.Int()%2]
+			}
+		} else if newValueInt, err = strconv.ParseInt(currentValue, 10, 64); err != nil {
+			return result, err
+		}
+		result, err = dsModels.NewInt64Value(ro, now, newValueInt)
+	}
+
+	if err != nil {
+		return result, err
+	}
+	err = db.updateResourceValue(result.ValueToString(), data.DeviceName, data.DeviceResourceName)
+	return result, err
+}
+
+func parseStrToInt(str string, bitSize int) (int64, error) {
+	if i, err := strconv.ParseInt(str, 10, bitSize); err != nil {
+		return i, err
+	} else {
+		return i, nil
+	}
+}
+
+func parseIntMinimumMaximum(minimum, maximum, dataType string) (int64, int64, error) {
+	var err, err1, err2 error
+	var min, max int64
+
+	switch dataType {
+	case typeInt8:
+		min, err1 = parseStrToInt(minimum, 8)
+		max, err2 = parseStrToInt(maximum, 8)
+		if max <= min || err1 != nil || err2 != nil {
+			min, max = int64(math.MinInt8), int64(math.MaxInt8)
+			err = fmt.Errorf("minimum:%s maximum:%s not in valid range, use default value", minimum, maximum)
+		}
+	case typeInt16:
+		min, err1 = parseStrToInt(minimum, 16)
+		max, err2 = parseStrToInt(maximum, 16)
+		if max <= min || err1 != nil || err2 != nil {
+			min, max = int64(math.MinInt16), int64(math.MaxInt16)
+			err = fmt.Errorf("minimum:%s maximum:%s not in valid range, use default value", minimum, maximum)
+		}
+	case typeInt32:
+		min, err1 = parseStrToInt(minimum, 32)
+		max, err2 = parseStrToInt(maximum, 32)
+		if max <= min || err1 != nil || err2 != nil {
+			err = fmt.Errorf("minimum:%s maximum:%s not in valid range, use default value", minimum, maximum)
+		}
+	case typeInt64:
+		min, err1 = parseStrToInt(minimum, 64)
+		max, err2 = parseStrToInt(maximum, 64)
+		if max <= min || err1 != nil || err2 != nil {
+			err = fmt.Errorf("minimum:%s maximum:%s not in valid range, use default value", minimum, maximum)
+		}
+	}
+	return min, max, err
+}
+
+func randomInt(min, max int64) int64 {
+	if max > 0 && min < 0 {
+		var negativePart int64
+		var positivePart int64
+		//min~0
+		if min == int64(math.MinInt64) {
+			negativePart = rand.Int63n(int64(math.MaxInt64)) + min - rand.Int63n(int64(1))
+		} else {
+			negativePart = rand.Int63n(-min+int64(1)) + min
+		}
+		//0~max
+		if max == int64(math.MaxInt64) {
+			positivePart = rand.Int63n(max) + rand.Int63n(int64(1))
+		} else {
+			positivePart = rand.Int63n(max + int64(1))
+		}
+		return negativePart + positivePart
+	} else {
+		if max == int64(math.MaxInt64) && min == 0 {
+			return rand.Int63n(max) + rand.Int63n(int64(1))
+		} else if min == int64(math.MinInt64) && max == 0 {
+			return rand.Int63n(int64(math.MaxInt64)) + min - rand.Int63n(int64(1))
+		} else {
+			return rand.Int63n(max-min+1) + min
+		}
+	}
+}
+
+func (ri *resourceInt) write(param *dsModels.CommandValue, deviceName string, db *db) error {
+	var err error
+	switch param.RO.Object {
+	case deviceResourceEnableRandomization:
+		v, err := param.BoolValue()
+		if err != nil {
+			return fmt.Errorf("resourceBool.write: %v", err)
+		}
+		if err := db.exec(SQL_UPDATE_ENABLERANDOMIZATION, v, deviceName, param.RO.Resource); err != nil {
+			return fmt.Errorf("resourceBool.write: %v", err)
+		} else {
+			return nil
+		}
+	case deviceResourceInt8:
+		_, err = param.Int8Value()
+	case deviceResourceInt16:
+		_, err = param.Int16Value()
+	case deviceResourceInt32:
+		_, err = param.Int32Value()
+	case deviceResourceInt64:
+		_, err = param.Int64Value()
+	default:
+		err = fmt.Errorf("resourceBool.write: unknown device resource: %s", param.RO.Object)
+	}
+
+	if err == nil {
+		return db.exec(SQL_UPDATE_VALUE, param.ValueToString(), deviceName, param.RO.Resource)
+	} else {
+		return err
+	}
+}

--- a/driver/resourceuint.go
+++ b/driver/resourceuint.go
@@ -1,0 +1,161 @@
+package driver
+
+import (
+	"fmt"
+	"math"
+	"math/rand"
+	"strconv"
+	"time"
+
+	dsModels "github.com/edgexfoundry/device-sdk-go/pkg/models"
+	"github.com/edgexfoundry/go-mod-core-contracts/models"
+)
+
+type resourceUint struct{}
+
+func (ru *resourceUint) value(db *db, ro *models.ResourceOperation, deviceName, deviceResourceName, minimum,
+	maximum string) (*dsModels.CommandValue, error) {
+	result := &dsModels.CommandValue{}
+
+	enableRandomization, currentValue, dataType, err := db.getVirtualResourceData(deviceName, deviceResourceName)
+	if err != nil {
+		return result, err
+	}
+
+	var newValueUint uint64
+	now := time.Now().UnixNano() / int64(time.Millisecond)
+	rand.Seed(time.Now().UnixNano())
+	min, max, err := parseUintMinimumMaximum(minimum, maximum, dataType)
+
+	switch dataType {
+	case typeUint8:
+		if enableRandomization {
+			newValueUint = randomUint(min, max)
+		} else if newValueUint, err = strconv.ParseUint(currentValue, 10, 8); err != nil {
+			return result, err
+		}
+		result, err = dsModels.NewUint8Value(ro, now, uint8(newValueUint))
+	case typeUint16:
+		if enableRandomization {
+			newValueUint = randomUint(min, max)
+		} else if newValueUint, err = strconv.ParseUint(currentValue, 10, 16); err != nil {
+			return result, err
+		}
+		result, err = dsModels.NewUint16Value(ro, now, uint16(newValueUint))
+	case typeUint32:
+		if enableRandomization {
+			if err == nil {
+				newValueUint = randomUint(min, max)
+			} else {
+				newValueUint = uint64(rand.Uint32())
+			}
+		} else if newValueUint, err = strconv.ParseUint(currentValue, 10, 32); err != nil {
+			return result, err
+		}
+		result, err = dsModels.NewUint32Value(ro, now, uint32(newValueUint))
+	case typeUint64:
+		if enableRandomization {
+			if err == nil {
+				newValueUint = randomUint(min, max)
+			} else {
+				newValueUint = rand.Uint64()
+			}
+		} else if newValueUint, err = strconv.ParseUint(currentValue, 10, 64); err != nil {
+			return result, err
+		}
+		result, err = dsModels.NewUint64Value(ro, now, newValueUint)
+	}
+
+	if err != nil {
+		return result, err
+	}
+	err = db.updateResourceValue(result.ValueToString(), data.DeviceName, data.DeviceResourceName)
+	return result, err
+}
+
+func randomUint(min, max uint64) uint64 {
+	rand.Seed(time.Now().UnixNano())
+	if max-min < uint64(math.MaxInt64) {
+		return uint64(rand.Int63n(int64(max-min+1))) + min
+	}
+	x := rand.Uint64()
+	for x > max-min {
+		x = rand.Uint64()
+	}
+	return x + min
+}
+
+func parseStrToUint(str string, bitSize int) (uint64, error) {
+	if i, err := strconv.ParseUint(str, 10, bitSize); err != nil {
+		return i, err
+	} else {
+		return i, nil
+	}
+}
+
+func parseUintMinimumMaximum(minimum, maximum, dataType string) (uint64, uint64, error) {
+	var err, err1, err2 error
+	var min, max uint64
+
+	switch dataType {
+	case typeUint8:
+		min, err1 = parseStrToUint(minimum, 8)
+		max, err2 = parseStrToUint(maximum, 8)
+		if max <= min || err1 != nil || err2 != nil {
+			min, max = uint64(0), uint64(math.MaxUint8)
+			err = fmt.Errorf("minimum:%s maximum:%s not in valid range, use default value", minimum, maximum)
+		}
+	case typeUint16:
+		min, err1 = parseStrToUint(minimum, 16)
+		max, err2 = parseStrToUint(maximum, 16)
+		if max <= min || err1 != nil || err2 != nil {
+			min, max = uint64(0), uint64(math.MaxUint16)
+			err = fmt.Errorf("minimum:%s maximum:%s not in valid range, use default value", minimum, maximum)
+		}
+	case typeUint32:
+		min, err1 = parseStrToUint(minimum, 32)
+		max, err2 = parseStrToUint(maximum, 32)
+		if max <= min || err1 != nil || err2 != nil {
+			err = fmt.Errorf("minimum:%s maximum:%s not in valid range, use default value", minimum, maximum)
+		}
+	case typeUint64:
+		min, err1 = parseStrToUint(minimum, 64)
+		max, err2 = parseStrToUint(maximum, 64)
+		if max <= min || err1 != nil || err2 != nil {
+			err = fmt.Errorf("minimum:%s maximum:%s not in valid range, use default value", minimum, maximum)
+		}
+	}
+	return min, max, err
+}
+
+func (ru *resourceUint) write(param *dsModels.CommandValue, deviceName string, db *db) error {
+	var err error
+	switch param.RO.Object {
+	case deviceResourceEnableRandomization:
+		v, err := param.BoolValue()
+		if err != nil {
+			return fmt.Errorf("resourceUint.write: %v", err)
+		}
+		if err := db.exec(SQL_UPDATE_ENABLERANDOMIZATION, v, deviceName, param.RO.Resource); err != nil {
+			return fmt.Errorf("resourceUint.write: %v", err)
+		} else {
+			return nil
+		}
+	case deviceResourceUint8:
+		_, err = param.Uint8Value()
+	case deviceResourceUint16:
+		_, err = param.Uint16Value()
+	case deviceResourceUint32:
+		_, err = param.Uint32Value()
+	case deviceResourceUint64:
+		_, err = param.Uint64Value()
+	default:
+		err = fmt.Errorf("resourceUint.write: unknown device resource: %s", param.RO.Object)
+	}
+
+	if err == nil {
+		return db.exec(SQL_UPDATE_VALUE, param.ValueToString(), deviceName, param.RO.Resource)
+	} else {
+		return err
+	}
+}

--- a/driver/virtualdevice.go
+++ b/driver/virtualdevice.go
@@ -8,458 +8,81 @@ package driver
 
 import (
 	"fmt"
-	"math"
-	"math/rand"
-	"strconv"
-	"time"
+
+	dsModels "github.com/edgexfoundry/device-sdk-go/pkg/models"
+	"github.com/edgexfoundry/go-mod-core-contracts/models"
 )
 
 const (
-	//defMinInt8, defMaxInt8   = math.MinInt8, math.MaxInt8
-	defMinInt8, defMaxInt8 = -100, 100
-	//defMinInt16, defMaxInt16 = math.MinInt16, math.MaxInt16
-	defMinInt16, defMaxInt16 = -100, 100
-	//defMinInt32, defMaxInt32 = math.MinInt32, math.MaxInt32
-	defMinInt32, defMaxInt32 = -100, 100
-	//defMinInt64, defMaxInt64 = math.MinInt64, math.MaxInt64
-	defMinInt64, defMaxInt64 = -100, 100
-	//defMinUint8, defMaxUint8 = 0, math.MaxUint8
-	defMinUint8, defMaxUint8 = 0, 100
-	//defMinUint16, defMaxUint16 = 0, math.MaxUint16
-	defMinUint16, defMaxUint16 = 0, 100
-	//defMinUint32, defMaxUint32 = 0, math.MaxUint32
-	defMinUint32, defMaxUint32 = 0, 100
-	//defMinUint64, defMaxUint64 = 0, math.MaxUint64
-	defMinUint64, defMaxUint64 = 0, 100
-	//defMinFloat32, defMaxFloat32 = -math.MaxFloat32, math.MaxFloat32
-	defMinFloat32, defMaxFloat32 = -100, 100
-	//defMinFloat64, defMaxFloat64 = -math.MaxFloat64, math.MaxFloat64
-	defMinFloat64, defMaxFloat64 = -100, 100
-	typeBool                     = "Bool"
-	typeInt8                     = "Int8"
-	typeInt16                    = "Int16"
-	typeInt32                    = "Int32"
-	typeInt64                    = "Int64"
-	typeUint8                    = "Uint8"
-	typeUint16                   = "Uint16"
-	typeUint32                   = "Uint32"
-	typeUint64                   = "Uint64"
-	typeFloat32                  = "Float32"
-	typeFloat64                  = "Float64"
+	typeBool                          = "Bool"
+	typeInt8                          = "Int8"
+	typeInt16                         = "Int16"
+	typeInt32                         = "Int32"
+	typeInt64                         = "Int64"
+	typeUint8                         = "Uint8"
+	typeUint16                        = "Uint16"
+	typeUint32                        = "Uint32"
+	typeUint64                        = "Uint64"
+	typeFloat32                       = "Float32"
+	typeFloat64                       = "Float64"
+	deviceResourceEnableRandomization = "Enable_Randomization"
+	deviceResourceBool                = "RandomValue_Bool"
+	deviceResourceInt8                = "RandomValue_Int8"
+	deviceResourceInt16               = "RandomValue_Int16"
+	deviceResourceInt32               = "RandomValue_Int32"
+	deviceResourceInt64               = "RandomValue_Int64"
+	deviceResourceUint8               = "RandomValue_Uint8"
+	deviceResourceUint16              = "RandomValue_Uint16"
+	deviceResourceUint32              = "RandomValue_Uint32"
+	deviceResourceUint64              = "RandomValue_Uint64"
+	deviceResourceFloat32             = "RandomValue_Float32"
+	deviceResourceFloat64             = "RandomValue_Float64"
 )
 
 type virtualDevice struct {
-	minInt8    int64
-	maxInt8    int64
-	minUint8   uint64
-	maxUint8   uint64
-	minInt16   int64
-	maxInt16   int64
-	minUint16  uint64
-	maxUint16  uint64
-	minInt32   int64
-	maxInt32   int64
-	minUint32  uint64
-	maxUint32  uint64
-	minInt64   int64
-	maxInt64   int64
-	minUint64  uint64
-	maxUint64  uint64
-	minFloat32 float64
-	maxFloat32 float64
-	minFloat64 float64
-	maxFloat64 float64
+	resourceBool  *resourceBool
+	resourceInt   *resourceInt
+	resourceUint  *resourceUint
+	resourceFloat *resourceFloat
 }
 
-func (d *virtualDevice) value(deviceName, deviceResourceName, minimum, maximum string, db *db) (string, error) {
-	rows, err := db.query(SQL_SELECT, deviceName, deviceResourceName)
-	if err != nil {
-		return "0", err
+func (d *virtualDevice) read(ro *models.ResourceOperation, deviceName, deviceResourceName, minimum, maximum string, db *db) (*dsModels.CommandValue, error) {
+	result := &dsModels.CommandValue{}
+
+	switch deviceResourceName {
+	case deviceResourceBool:
+		return d.resourceBool.value(db, ro, deviceName, deviceResourceName)
+	case deviceResourceInt8, deviceResourceInt16, deviceResourceInt32, deviceResourceInt64:
+		return d.resourceInt.value(db, ro, deviceName, deviceResourceName, minimum, maximum)
+	case deviceResourceUint8, deviceResourceUint16, deviceResourceUint32, deviceResourceUint64:
+		return d.resourceUint.value(db, ro, deviceName, deviceResourceName, minimum, maximum)
+	case deviceResourceFloat32, deviceResourceFloat64:
+		return d.resourceFloat.value(db, ro, deviceName, deviceResourceName, minimum, maximum)
+	default:
+		return result, fmt.Errorf("virtualDevice.read: wrong read type: %s", deviceResourceName)
 	}
+}
 
-	var data struct {
-		DeviceName          string
-		CommandName         string
-		DeviceResourceName  string
-		EnableRandomization string
-		DataType            string
-		Value               string
+func (d *virtualDevice) write(param *dsModels.CommandValue, deviceName string, db *db) error {
+	switch param.Type {
+	case dsModels.Bool:
+		return d.resourceBool.write(param, deviceName, db)
+	case dsModels.Int8, dsModels.Int16, dsModels.Int32, dsModels.Int64:
+		return d.resourceInt.write(param, deviceName, db)
+	case dsModels.Uint8, dsModels.Uint16, dsModels.Uint32, dsModels.Uint64:
+		return d.resourceUint.write(param, deviceName, db)
+	case dsModels.Float32, dsModels.Float64:
+		return d.resourceFloat.write(param, deviceName, db)
+	default:
+		return fmt.Errorf("VirtualDriver.HandleWriteCommands: there is no matched device resource for %s", param.String())
 	}
-
-	if rows.Next() {
-		if err = rows.Scan(&data.DeviceName, &data.CommandName, &data.DeviceResourceName, &data.EnableRandomization, &data.DataType, &data.Value); err != nil {
-			rows.Close()
-			return "0", err
-		}
-		rows.Close()
-	}
-
-	if er, _ := strconv.ParseBool(data.EnableRandomization); er {
-		var newValueInt int64
-		var newValueUint uint64
-		var newValueFloat float64
-		var newValueBool bool
-		var para1 string
-
-		switch data.DataType {
-		case typeBool:
-			newValueBool = randomBool()
-			para1 = strconv.FormatBool(newValueBool)
-		case typeInt8:
-			min, err := parseStrToInt(minimum, typeInt8)
-			if err != nil {
-				return "0", err
-			}
-			max, err := parseStrToInt(maximum, typeInt8)
-			if err != nil {
-				return "0", err
-			}
-			if min < d.minInt8 {
-				return "0", fmt.Errorf("virtualDevice.value: the minimum value of %s is: %d ", typeInt8, d.minInt8)
-			}
-			if max > d.maxInt8 {
-				return "0", fmt.Errorf("virtualDevice.value: the maximum value of %s is: %d ", typeInt8, d.maxInt8)
-			}
-
-			if max <= min {
-				return "0", fmt.Errorf("virtualDevice.value: maximum: %d <= minimum : %d", max, min)
-			} else {
-				newValueInt = randomInt(min, max)
-				para1 = strconv.FormatInt(newValueInt, 10)
-			}
-		case typeUint8:
-			min, err := parseStrToUint(minimum, typeUint8)
-			if err != nil {
-				return "0", err
-			}
-			max, err := parseStrToUint(maximum, typeUint8)
-			if err != nil {
-				return "0", err
-			}
-			if min < d.minUint16 {
-				return "0", fmt.Errorf("virtualDevice.value: the minimum value of %s is: %d ", typeUint8, d.minUint8)
-			}
-			if max > d.maxUint16 {
-				return "0", fmt.Errorf("virtualDevice.value: the maximum value of %s is: %d ", typeUint8, d.maxUint8)
-			}
-
-			if max <= min {
-				return "0", fmt.Errorf("virtualDevice.value: maximum: %d <= minimum : %d", max, min)
-			} else {
-				newValueUint = randomUint(min, max)
-				para1 = strconv.FormatUint(newValueUint, 10)
-			}
-		case typeInt16:
-			min, err := parseStrToInt(minimum, typeInt16)
-			if err != nil {
-				return "0", err
-			}
-			max, err := parseStrToInt(maximum, typeInt16)
-			if err != nil {
-				return "0", err
-			}
-			if min < d.minInt16 {
-				return "0", fmt.Errorf("virtualDevice.value: the minimum value of %s is: %d ", typeInt16, d.minInt16)
-			}
-			if max > d.maxInt16 {
-				return "0", fmt.Errorf("virtualDevice.value: the maximum value of %s is: %d ", typeInt16, d.maxInt16)
-			}
-
-			if max <= min {
-				return "0", fmt.Errorf("virtualDevice.value: maximum: %d <= minimum : %d", max, min)
-			} else {
-				newValueInt = randomInt(min, max)
-				para1 = strconv.FormatInt(newValueInt, 10)
-			}
-		case typeUint16:
-			min, err := parseStrToUint(minimum, typeUint16)
-			if err != nil {
-				return "0", err
-			}
-			max, err := parseStrToUint(maximum, typeUint16)
-			if err != nil {
-				return "0", err
-			}
-			if min < d.minUint16 {
-				return "0", fmt.Errorf("virtualDevice.value: the minimum value of %s is: %d ", typeUint16, d.minUint16)
-			}
-			if max > d.maxUint16 {
-				return "0", fmt.Errorf("virtualDevice.value: the maximum value of %s is: %d ", typeUint16, d.maxUint16)
-			}
-
-			if max <= min {
-				return "0", fmt.Errorf("virtualDevice.value: maximum: %d <= minimum : %d", max, min)
-			} else {
-				newValueUint = randomUint(min, max)
-				para1 = strconv.FormatUint(newValueUint, 10)
-			}
-		case typeInt32:
-			min, err := parseStrToInt(minimum, typeInt32)
-			if err != nil {
-				return "0", err
-			}
-			max, err := parseStrToInt(maximum, typeInt32)
-			if err != nil {
-				return "0", err
-			}
-			if min < d.minInt32 {
-				return "0", fmt.Errorf("virtualDevice.value: the minimum value of %s is: %d ", typeInt32, d.minInt32)
-			}
-			if max > d.maxInt32 {
-				return "0", fmt.Errorf("virtualDevice.value: the maximum value of %s is: %d ", typeInt32, d.maxInt32)
-			}
-
-			if max <= min {
-				return "0", fmt.Errorf("virtualDevice.value: maximum: %d <= minimum : %d", max, min)
-			} else {
-				newValueInt = randomInt(min, max)
-				para1 = strconv.FormatInt(newValueInt, 10)
-			}
-		case typeUint32:
-			min, err := parseStrToUint(minimum, typeUint32)
-			if err != nil {
-				return "0", err
-			}
-			max, err := parseStrToUint(maximum, typeUint32)
-			if err != nil {
-				return "0", err
-			}
-			if min < d.minUint32 {
-				return "0", fmt.Errorf("virtualDevice.value: the minimum value of %s is: %d ", typeUint32, d.minUint32)
-			}
-			if max > d.maxUint32 {
-				return "0", fmt.Errorf("virtualDevice.value: the maximum value of %s is: %d ", typeUint32, d.maxUint32)
-			}
-
-			if max <= min {
-				return "0", fmt.Errorf("virtualDevice.value: maximum: %d <= minimum : %d", max, min)
-			} else {
-				newValueUint = randomUint(min, max)
-				para1 = strconv.FormatUint(newValueUint, 10)
-			}
-		case typeInt64:
-			min, err := parseStrToInt(minimum, typeInt64)
-			if err != nil {
-				return "0", err
-			}
-			max, err := parseStrToInt(maximum, typeInt64)
-			if err != nil {
-				return "0", err
-			}
-			if min < d.minInt64 {
-				return "0", fmt.Errorf("virtualDevice.value: the minimum value of %s is: %d ", typeInt64, d.minInt64)
-			}
-			if max > d.maxInt64 {
-
-				return "0", fmt.Errorf("virtualDevice.value: the maximum value of %s is: %d ", typeInt64, d.maxInt64)
-			}
-
-			if max <= min {
-				return "0", fmt.Errorf("virtualDevice.value: maximum: %d <= minimum : %d", max, min)
-			} else {
-				newValueInt = randomInt(min, max)
-				para1 = strconv.FormatInt(newValueInt, 10)
-			}
-		case typeUint64:
-			min, err := parseStrToUint(minimum, typeUint64)
-			if err != nil {
-				return "0", err
-			}
-			max, err := parseStrToUint(maximum, typeUint64)
-			if err != nil {
-				return "0", err
-			}
-			if min < d.minUint64 {
-				return "0", fmt.Errorf("virtualDevice.value: the minimum value of %s is: %d ", typeUint64, d.minUint64)
-			}
-			if max > d.maxUint64 {
-				return "0", fmt.Errorf("virtualDevice.value: the maximum value of %s is: %d ", typeUint64, d.maxUint64)
-			}
-
-			if max <= min {
-				return "0", fmt.Errorf("virtualDevice.value: maximum: %d <= minimum : %d", max, min)
-			} else {
-				newValueUint = randomUint(min, max)
-				para1 = strconv.FormatUint(newValueUint, 10)
-			}
-		case typeFloat32:
-			min, err := parseStrToFloat(minimum, typeFloat32)
-			if err != nil {
-				return "0", err
-			}
-			max, err := parseStrToFloat(maximum, typeFloat32)
-			if err != nil {
-				return "0", err
-			}
-			if min < d.minFloat32 {
-				return "0", fmt.Errorf("virtualDevice.value: the minimum value of %s is: %f ", typeFloat32, d.minFloat32)
-			}
-			if max > d.maxFloat32 {
-				return "0", fmt.Errorf("virtualDevice.value: the maximum value of %s is: %f ", typeFloat32, d.maxFloat32)
-			}
-
-			if max <= min {
-				return "0", fmt.Errorf("virtualDevice.value: maximum: %f <= minimum : %f", max, min)
-			} else {
-				newValueFloat = randomFloat(min, max)
-				para1 = strconv.FormatFloat(newValueFloat, 'f', -1, 32)
-			}
-		case typeFloat64:
-			min, err := parseStrToFloat(minimum, typeFloat64)
-			if err != nil {
-				return "0", err
-			}
-			max, err := parseStrToFloat(maximum, typeFloat64)
-			if err != nil {
-				return "0", err
-			}
-			if min < d.minFloat64 {
-				return "0", fmt.Errorf("virtualDevice.value: the minimum value of %s is: %f ", typeFloat64, d.minFloat64)
-			}
-			if max > d.maxFloat64 {
-				return "0", fmt.Errorf("virtualDevice.value: the maximum value of %s is: %f ", typeFloat64, d.maxFloat64)
-			}
-
-			if max <= min {
-				return "0", fmt.Errorf("virtualDevice.value: maximum: %f <= minimum : %f", max, min)
-			} else {
-				newValueFloat = randomFloat(min, max)
-				para1 = strconv.FormatFloat(newValueFloat, 'f', -1, 64)
-			}
-		default:
-			return "0", fmt.Errorf("virtualDevice.value: wrong value type: %s", deviceResourceName)
-		}
-
-		if err := db.exec(SQL_UPDATE_VALUE, para1, data.DeviceName, data.CommandName); err != nil {
-			return "0", err
-		}
-		return para1, nil
-	} else {
-		return data.Value, nil
-	}
-
 }
 
 func newVirtualDevice() *virtualDevice {
 	return &virtualDevice{
-		minInt8:    defMinInt8,
-		maxInt8:    defMaxInt8,
-		minUint8:   defMinUint8,
-		maxUint8:   defMaxUint8,
-		minInt16:   defMinInt16,
-		maxInt16:   defMaxInt16,
-		minUint16:  defMinUint16,
-		maxUint16:  defMaxUint16,
-		minInt32:   defMinInt32,
-		maxInt32:   defMaxInt32,
-		minUint32:  defMinUint32,
-		maxUint32:  defMaxUint32,
-		minInt64:   defMinInt64,
-		maxInt64:   defMaxInt64,
-		minUint64:  defMinUint64,
-		maxUint64:  defMaxUint64,
-		minFloat32: defMinFloat32,
-		maxFloat32: defMaxFloat32,
-		minFloat64: defMinFloat64,
-		maxFloat64: defMaxFloat64,
-	}
-}
-
-func randomInt(min, max int64) int64 {
-	rand.Seed(time.Now().UnixNano())
-	if max-min == -1 {
-		return (rand.Int63n(max/2-min/2) + min/2) * 2
-	} else {
-		return rand.Int63n(max-min+1) + min
-	}
-}
-
-func randomUint(min, max uint64) uint64 {
-	rand.Seed(time.Now().UnixNano())
-	if max-min < math.MaxInt64 {
-		return uint64(rand.Int63n(int64(max-min+1))) + min
-	}
-	x := rand.Uint64()
-	for x > max-min {
-		x = rand.Uint64()
-	}
-	return x
-}
-
-func randomFloat(min, max float64) float64 {
-	rand.Seed(time.Now().UnixNano())
-	return rand.Float64()*(max-min) + min
-}
-
-func randomBool() bool {
-	rand.Seed(time.Now().UnixNano())
-	return rand.Int()%2 == 0
-}
-
-func parseStrToInt(s, dt string) (int64, error) {
-	v := int64(0)
-	var err error
-
-	switch dt {
-	case typeInt8:
-		v, err = strconv.ParseInt(s, 10, 8)
-	case typeInt16:
-		v, err = strconv.ParseInt(s, 10, 16)
-	case typeInt32:
-		v, err = strconv.ParseInt(s, 10, 32)
-	case typeInt64:
-		v, err = strconv.ParseInt(s, 10, 64)
-	default:
-		return v, fmt.Errorf("virtualDevice.value: unknown data type: %s ", dt)
-	}
-
-	if err != nil {
-		return v, fmt.Errorf("virtualDevice.value: error when parsing string to %s : %s ", dt, s)
-	} else {
-		return v, nil
-	}
-}
-
-func parseStrToUint(s, dt string) (uint64, error) {
-	v := uint64(0)
-	var err error
-
-	switch dt {
-	case typeUint8:
-		v, err = strconv.ParseUint(s, 10, 8)
-	case typeUint16:
-		v, err = strconv.ParseUint(s, 10, 16)
-	case typeUint32:
-		v, err = strconv.ParseUint(s, 10, 32)
-	case typeUint64:
-		v, err = strconv.ParseUint(s, 10, 64)
-	default:
-		return v, fmt.Errorf("virtualDevice.value: unknown data type: %s ", dt)
-	}
-
-	if err != nil {
-		return v, fmt.Errorf("virtualDevice.value: error when parsing string to %s : %s ", dt, s)
-	} else {
-		return v, nil
-	}
-}
-
-func parseStrToFloat(s, dt string) (float64, error) {
-	v := float64(0)
-	var err error
-
-	switch dt {
-	case typeFloat32:
-		v, err = strconv.ParseFloat(s, 32)
-	case typeFloat64:
-		v, err = strconv.ParseFloat(s, 64)
-	default:
-		return v, fmt.Errorf("virtualDevice.value: unknown data type: %s ", dt)
-	}
-
-	if err != nil {
-		return v, fmt.Errorf("virtualDevice.value: error when parsing string to %s : %s ", dt, s)
-	} else {
-		return v, nil
+		resourceBool:  &resourceBool{},
+		resourceInt:   &resourceInt{},
+		resourceUint:  &resourceUint{},
+		resourceFloat: &resourceFloat{},
 	}
 }

--- a/driver/virtualdevice_test.go
+++ b/driver/virtualdevice_test.go
@@ -5,22 +5,25 @@ import (
 	"os"
 	"strconv"
 	"testing"
+
+	dsModels "github.com/edgexfoundry/device-sdk-go/pkg/models"
+	"github.com/edgexfoundry/go-mod-core-contracts/models"
 )
 
 const (
-	DeviceName                                        = "Random-Value-Generator01"
-	DeviceCommandName_Bool, DeviceResource_Bool       = "RandomValue_Bool", "RandomValue_Bool"
-	DeviceCommandName_Int8, DeviceResource_Int8       = "RandomValue_Int8", "RandomValue_Int8"
-	DeviceCommandName_Int16, DeviceResource_Int16     = "RandomValue_Int16", "RandomValue_Int16"
-	DeviceCommandName_Int32, DeviceResource_Int32     = "RandomValue_Int32", "RandomValue_Int32"
-	DeviceCommandName_Int64, DeviceResource_Int64     = "RandomValue_Int64", "RandomValue_Int64"
-	DeviceCommandName_Uint8, DeviceResource_Uint8     = "RandomValue_Uint8", "RandomValue_Uint8"
-	DeviceCommandName_Uint16, DeviceResource_Uint16   = "RandomValue_Uint16", "RandomValue_Uint16"
-	DeviceCommandName_Uint32, DeviceResource_Uint32   = "RandomValue_Uint32", "RandomValue_Uint32"
-	DeviceCommandName_Uint64, DeviceResource_Uint64   = "RandomValue_Uint64", "RandomValue_Uint64"
-	DeviceCommandName_Float32, DeviceResource_Float32 = "RandomValue_Float32", "RandomValue_Float32"
-	DeviceCommandName_Float64, DeviceResource_Float64 = "RandomValue_Float64", "RandomValue_Float64"
-	EnableRandomization_True                          = "true"
+	deviceName               = "Random-Value-Generator01"
+	deviceCommandNameBool    = "RandomValue_Bool"
+	deviceCommandNameInt8    = "RandomValue_Int8"
+	deviceCommandNameInt16   = "RandomValue_Int16"
+	deviceCommandNameInt32   = "RandomValue_Int32"
+	deviceCommandNameInt64   = "RandomValue_Int64"
+	deviceCommandNameUint8   = "RandomValue_Uint8"
+	deviceCommandNameUint16  = "RandomValue_Uint16"
+	deviceCommandNameUint32  = "RandomValue_Uint32"
+	deviceCommandNameUint64  = "RandomValue_Uint64"
+	deviceCommandNameFloat32 = "RandomValue_Float32"
+	deviceCommandNameFloat64 = "RandomValue_Float64"
+	enableRandomizationTrue  = "true"
 )
 
 func init() {
@@ -51,17 +54,17 @@ func init() {
 	}
 
 	ds := [][]string{
-		{DeviceName, DeviceCommandName_Bool, DeviceResource_Bool, EnableRandomization_True, typeBool, "true"},
-		{DeviceName, DeviceCommandName_Int8, DeviceResource_Int8, EnableRandomization_True, typeInt8, "0"},
-		{DeviceName, DeviceCommandName_Int16, DeviceResource_Int16, EnableRandomization_True, typeInt16, "0"},
-		{DeviceName, DeviceCommandName_Int32, DeviceResource_Int32, EnableRandomization_True, typeInt32, "0"},
-		{DeviceName, DeviceCommandName_Int64, DeviceResource_Int64, EnableRandomization_True, typeInt64, "0"},
-		{DeviceName, DeviceCommandName_Uint8, DeviceResource_Uint8, EnableRandomization_True, typeUint8, "0"},
-		{DeviceName, DeviceCommandName_Uint16, DeviceResource_Uint16, EnableRandomization_True, typeUint16, "0"},
-		{DeviceName, DeviceCommandName_Uint32, DeviceResource_Uint32, EnableRandomization_True, typeUint32, "0"},
-		{DeviceName, DeviceCommandName_Uint64, DeviceResource_Uint64, EnableRandomization_True, typeUint64, "0"},
-		{DeviceName, DeviceCommandName_Float32, DeviceResource_Float32, EnableRandomization_True, typeFloat32, "0"},
-		{DeviceName, DeviceCommandName_Float64, DeviceResource_Float64, EnableRandomization_True, typeFloat64, "0"},
+		{deviceName, deviceCommandNameBool, deviceResourceBool, enableRandomizationTrue, typeBool, "true"},
+		{deviceName, deviceCommandNameInt8, deviceResourceInt8, enableRandomizationTrue, typeInt8, "0"},
+		{deviceName, deviceCommandNameInt16, deviceResourceInt16, enableRandomizationTrue, typeInt16, "0"},
+		{deviceName, deviceCommandNameInt32, deviceResourceInt32, enableRandomizationTrue, typeInt32, "0"},
+		{deviceName, deviceCommandNameInt64, deviceResourceInt64, enableRandomizationTrue, typeInt64, "0"},
+		{deviceName, deviceCommandNameUint8, deviceResourceUint8, enableRandomizationTrue, typeUint8, "0"},
+		{deviceName, deviceCommandNameUint16, deviceResourceUint16, enableRandomizationTrue, typeUint16, "0"},
+		{deviceName, deviceCommandNameUint32, deviceResourceUint32, enableRandomizationTrue, typeUint32, "0"},
+		{deviceName, deviceCommandNameUint64, deviceResourceUint64, enableRandomizationTrue, typeUint64, "0"},
+		{deviceName, deviceCommandNameFloat32, deviceResourceFloat32, enableRandomizationTrue, typeFloat32, "0"},
+		{deviceName, deviceCommandNameFloat64, deviceResourceFloat64, enableRandomizationTrue, typeFloat64, "0"},
 	}
 	for _, d := range ds {
 		b, _ := strconv.ParseBool(d[3])
@@ -83,14 +86,14 @@ func TestValue_Bool(t *testing.T) {
 		}
 	}()
 
-	rd := newVirtualDevice()
-	v1, err := rd.value(DeviceName, DeviceResource_Bool, "", "", db)
+	vd := newVirtualDevice()
+	v1, err := vd.read(&models.ResourceOperation{}, deviceName, deviceResourceBool, "", "", db)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	//the return string must be convertible to boolean
-	b1, err := strconv.ParseBool(v1)
+	b1, err := v1.BoolValue()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -98,52 +101,62 @@ func TestValue_Bool(t *testing.T) {
 	rounds := 20
 	//EnableRandomization = true
 	for x := 1; x <= rounds; x++ {
-		v2, _ := rd.value(DeviceName, DeviceResource_Bool, "", "", db)
-		b2, _ := strconv.ParseBool(v2)
+		v2, _ := vd.read(&models.ResourceOperation{}, deviceName, deviceResourceBool, "", "", db)
+		b2, _ := v2.BoolValue()
 		if b1 != b2 {
 			break
 		}
 		if x == rounds {
-			t.Fatalf("EnableRandomization is true, but got same value in %d rounds", rounds)
+			t.Fatalf("EnableRandomization is true, but got same read in %d rounds", rounds)
 		}
 	}
 
 	//EnableRandomization = false
-	if err := db.exec(SQL_UPDATE_ENABLERANDOMIZATION, false, DeviceName, DeviceResource_Bool); err != nil {
+	if err := db.exec(SQL_UPDATE_ENABLERANDOMIZATION, false, deviceName, deviceResourceBool); err != nil {
 		t.Fatal(err)
 	}
 
-	v1, _ = rd.value(DeviceName, DeviceResource_Bool, "", "", db)
-	b1, _ = strconv.ParseBool(v1)
+	v1, _ = vd.read(&models.ResourceOperation{}, deviceName, deviceResourceBool, "", "", db)
+	b1, _ = v1.BoolValue()
 	for x := 0; x <= rounds; x++ {
-		v2, _ := rd.value(DeviceName, DeviceResource_Bool, "", "", db)
-		b2, _ := strconv.ParseBool(v2)
+		v2, _ := vd.read(&models.ResourceOperation{}, deviceName, deviceResourceBool, "", "", db)
+		b2, _ := v2.BoolValue()
 		if b1 != b2 {
-			t.Fatalf("EnableRandomization is false, but got different value")
+			t.Fatalf("EnableRandomization is false, but got different read")
 		}
 	}
 }
 
 func TestValueIntx(t *testing.T) {
-	SubTestValueIntx(t, DeviceResource_Int8)
-	SubTestValueIntx(t, DeviceResource_Int16)
-	SubTestValueIntx(t, DeviceResource_Int32)
-	SubTestValueIntx(t, DeviceResource_Int64)
+	ValueIntx(t, deviceResourceInt8, "-128", "127")
+	ValueIntx(t, deviceResourceInt8, "", "")
+	ValueIntx(t, deviceResourceInt16, "-32768", "32767")
+	ValueIntx(t, deviceResourceInt16, "", "")
+	ValueIntx(t, deviceResourceInt32, "-2147483648", "2147483647")
+	ValueIntx(t, deviceResourceInt32, "", "")
+	ValueIntx(t, deviceResourceInt64, "-9223372036854775808", "9223372036854775807")
+	ValueIntx(t, deviceResourceInt64, "", "")
 }
 
 func TestValueUintx(t *testing.T) {
-	SubTestValueUintx(t, DeviceResource_Uint8)
-	SubTestValueUintx(t, DeviceResource_Uint16)
-	SubTestValueUintx(t, DeviceResource_Uint32)
-	SubTestValueUintx(t, DeviceResource_Uint64)
+	ValueUintx(t, deviceResourceUint8, "0", "255")
+	ValueUintx(t, deviceResourceUint8, "", "")
+	ValueUintx(t, deviceResourceUint16, "0", "65535")
+	ValueUintx(t, deviceResourceUint16, "", "")
+	ValueUintx(t, deviceResourceUint32, "0", "4294967295")
+	ValueUintx(t, deviceResourceUint32, "", "")
+	ValueUintx(t, deviceResourceUint64, "0", "18446744073709551615")
+	ValueUintx(t, deviceResourceUint64, "", "")
 }
 
 func TestValueFloatx(t *testing.T) {
-	SubTestValueFloatx(t, DeviceResource_Float32)
-	SubTestValueFloatx(t, DeviceResource_Float64)
+	ValueFloatx(t, deviceResourceFloat32, "-3.40282346638528859811704183484516925440e+38", "3.40282346638528859811704183484516925440e+38")
+	ValueFloatx(t, deviceResourceFloat32, "", "")
+	ValueFloatx(t, deviceResourceFloat64, "-1.797693134862315708145274237317043567981e+308", "1.797693134862315708145274237317043567981e+308")
+	ValueFloatx(t, deviceResourceFloat64, "", "")
 }
 
-func SubTestValueIntx(t *testing.T, dr string) {
+func ValueIntx(t *testing.T, dr, minStr, maxStr string) {
 	db := getDb()
 	if err := db.openDb(); err != nil {
 		t.Fatal(err)
@@ -154,47 +167,26 @@ func SubTestValueIntx(t *testing.T, dr string) {
 		}
 	}()
 
-	rd := newVirtualDevice()
-
-	var minInt, maxInt int64
-	var bitSize int
-	switch dr {
-	case DeviceResource_Int8:
-		minInt, maxInt = rd.minInt8, rd.maxInt8
-		bitSize = 8
-	case DeviceResource_Int16:
-		minInt, maxInt = rd.minInt16, rd.maxInt16
-		bitSize = 16
-	case DeviceResource_Int32:
-		minInt, maxInt = rd.minInt32, rd.maxInt32
-		bitSize = 32
-	case DeviceResource_Int64:
-		minInt, maxInt = rd.minInt64, rd.maxInt64
-		bitSize = 64
-	default:
-		t.Fatal("unknown device resource:", dr)
+	//EnableRandomization = true
+	if err := db.exec(SQL_UPDATE_ENABLERANDOMIZATION, true, deviceName, dr); err != nil {
+		t.Fatal(err)
 	}
 
-	if _, err := rd.value(DeviceName, dr, strconv.FormatInt(minInt-1, 10), strconv.FormatInt(maxInt, 10), db); err == nil {
-		t.Fatalf("when using the minimum value of %s to minus 1, expected to get an error", dr)
-	}
-	if _, err := rd.value(DeviceName, dr, strconv.FormatInt(minInt, 10), strconv.FormatInt(maxInt+1, 10), db); err == nil {
-		t.Fatalf("when using the maximum value of %s to plus 1, expected to get an error", dr)
-	}
+	vd := newVirtualDevice()
 
 	rounds := 100
 
-	//EnableRandomization = true
+	min, _ := parseStrToInt(minStr, 64)
+	max, _ := parseStrToInt(maxStr, 64)
+
+	var i1 int64
 	for x := 1; x <= rounds; x++ {
-		vn, err := rd.value(DeviceName, dr, strconv.FormatInt(minInt, 10), strconv.FormatInt(maxInt, 10), db)
+		vn, err := vd.read(&models.ResourceOperation{}, deviceName, dr, minStr, maxStr, db)
 		if err != nil {
 			t.Fatal(err)
 		}
-		in, err := strconv.ParseInt(vn, 10, bitSize)
-		if err != nil {
-			t.Fatal(err)
-		}
-		var i1 int64
+		in := getIntValue(vn)
+
 		if x == 1 {
 			i1 = in
 		}
@@ -202,42 +194,45 @@ func SubTestValueIntx(t *testing.T, dr string) {
 			break
 		}
 		if x == rounds {
-			t.Fatalf("EnableRandomization is true, but got same value in %d rounds", rounds)
+			t.Fatalf("EnableRandomization is true, but got same read in %d rounds", rounds)
 		}
 	}
 
-	//generate value 100 times
+	//generate read 100 times
 	for x := 1; x <= rounds; x++ {
-		v, err := rd.value(DeviceName, dr, strconv.FormatInt(minInt, 10), strconv.FormatInt(maxInt, 10), db)
+		v, err := vd.read(&models.ResourceOperation{}, deviceName, dr, minStr, maxStr, db)
+
 		if err != nil {
 			t.Fatal(err)
 		}
-		i, err := strconv.ParseInt(v, 10, bitSize)
+		i := getIntValue(v)
 		if err != nil {
 			t.Fatal(err)
 		}
-		if i < minInt || i > maxInt {
-			t.Fatalf("random value: %d,  out of range: %d ~ %d", i, minInt, maxInt)
+		if minStr != "" && maxStr != "" {
+			if i < min || i > max {
+				t.Fatalf("random read: %d,  out of range: %s ~ %s", i, minStr, maxStr)
+			}
 		}
 	}
 
 	//EnableRandomization = false
-	if err := db.exec(SQL_UPDATE_ENABLERANDOMIZATION, false, DeviceName, dr); err != nil {
+	if err := db.exec(SQL_UPDATE_ENABLERANDOMIZATION, false, deviceName, dr); err != nil {
 		t.Fatal(err)
 	}
 
-	v1, _ := rd.value(DeviceName, dr, strconv.FormatInt(minInt, 10), strconv.FormatInt(maxInt, 10), db)
-	i1, _ := strconv.ParseInt(v1, 10, bitSize)
+	v1, _ := vd.read(&models.ResourceOperation{}, deviceName, dr, minStr, maxStr, db)
+	i1 = getIntValue(v1)
 	for x := 1; x <= rounds; x++ {
-		v2, _ := rd.value(DeviceName, dr, strconv.FormatInt(minInt, 10), strconv.FormatInt(maxInt, 10), db)
-		i2, _ := strconv.ParseInt(v2, 10, bitSize)
+		v2, _ := vd.read(&models.ResourceOperation{}, deviceName, dr, minStr, maxStr, db)
+		i2 := getIntValue(v2)
 		if i1 != i2 {
-			t.Fatalf("EnableRandomization is false, but got different value")
+			t.Fatalf("EnableRandomization is false, but got different read")
 		}
 	}
 }
 
-func SubTestValueUintx(t *testing.T, dr string) {
+func ValueUintx(t *testing.T, dr, minStr, maxStr string) {
 	db := getDb()
 	if err := db.openDb(); err != nil {
 		t.Fatal(err)
@@ -248,41 +243,23 @@ func SubTestValueUintx(t *testing.T, dr string) {
 		}
 	}()
 
-	rd := newVirtualDevice()
-
-	var minUint, maxUint uint64
-	var bitSize int
-	switch dr {
-	case DeviceResource_Uint8:
-		minUint, maxUint = rd.minUint8, rd.maxUint8
-		bitSize = 8
-	case DeviceResource_Uint16:
-		minUint, maxUint = rd.minUint16, rd.maxUint16
-		bitSize = 16
-	case DeviceResource_Uint32:
-		minUint, maxUint = rd.minUint32, rd.maxUint32
-		bitSize = 32
-	case DeviceResource_Uint64:
-		minUint, maxUint = rd.minUint64, rd.maxUint64
-		bitSize = 64
-	default:
-		t.Fatal("unknown device resource:", dr)
+	//EnableRandomization = true
+	if err := db.exec(SQL_UPDATE_ENABLERANDOMIZATION, true, deviceName, dr); err != nil {
+		t.Fatal(err)
 	}
 
-	if _, err := rd.value(DeviceName, dr, strconv.FormatUint(minUint-1, 10), strconv.FormatUint(maxUint, 10), db); err == nil {
-		t.Fatalf("when using the minimum value of %s to minus 1, expected to get an error", dr)
-	}
-	if _, err := rd.value(DeviceName, dr, strconv.FormatUint(minUint, 10), strconv.FormatUint(maxUint+1, 10), db); err == nil {
-		t.Fatalf("when using the maximum value of %s to plus 1, expected to get an error", dr)
-	}
+	vd := newVirtualDevice()
 
 	rounds := 100
 
-	//EnableRandomization = true
+	min, _ := parseStrToUint(minStr, 64)
+	max, _ := parseStrToUint(maxStr, 64)
+
+	var i1 uint64
 	for x := 1; x <= rounds; x++ {
-		vn, _ := rd.value(DeviceName, dr, strconv.FormatUint(minUint, 10), strconv.FormatUint(maxUint, 10), db)
-		in, _ := strconv.ParseUint(vn, 10, bitSize)
-		var i1 uint64
+		vn, _ := vd.read(&models.ResourceOperation{}, deviceName, dr, minStr, maxStr, db)
+		in := getUintValue(vn)
+
 		if x == 1 {
 			i1 = in
 		}
@@ -290,42 +267,44 @@ func SubTestValueUintx(t *testing.T, dr string) {
 			break
 		}
 		if x == rounds {
-			t.Fatalf("EnableRandomization is true, but got same value in %d rounds", rounds)
+			t.Fatalf("EnableRandomization is true, but got same read in %d rounds", rounds)
 		}
 	}
 
-	//generate value 100 times
+	//generate read 100 times
 	for x := 1; x <= rounds; x++ {
-		v, err := rd.value(DeviceName, dr, strconv.FormatUint(minUint, 10), strconv.FormatUint(maxUint, 10), db)
+		v, err := vd.read(&models.ResourceOperation{}, deviceName, dr, minStr, maxStr, db)
 		if err != nil {
 			t.Fatal(err)
 		}
-		i, err := strconv.ParseUint(v, 10, bitSize)
+		i := getUintValue(v)
 		if err != nil {
 			t.Fatal(err)
 		}
-		if i < minUint || i > maxUint {
-			t.Fatalf("random value: %d,  out of range: %d ~ %d", i, minUint, maxUint)
+		if minStr != "" && maxStr != "" {
+			if i < min || i > max {
+				t.Fatalf("random read: %d,  out of range: %d ~ %d", i, min, max)
+			}
 		}
 	}
 
 	//EnableRandomization = false
-	if err := db.exec(SQL_UPDATE_ENABLERANDOMIZATION, false, DeviceName, dr); err != nil {
+	if err := db.exec(SQL_UPDATE_ENABLERANDOMIZATION, false, deviceName, dr); err != nil {
 		t.Fatal(err)
 	}
 
-	v1, _ := rd.value(DeviceName, dr, strconv.FormatUint(minUint, 10), strconv.FormatUint(maxUint, 10), db)
-	i1, _ := strconv.ParseUint(v1, 10, bitSize)
+	v1, _ := vd.read(&models.ResourceOperation{}, deviceName, dr, minStr, maxStr, db)
+	i1 = getUintValue(v1)
 	for x := 1; x <= rounds; x++ {
-		v2, _ := rd.value(DeviceName, dr, strconv.FormatUint(minUint, 10), strconv.FormatUint(maxUint, 10), db)
-		i2, _ := strconv.ParseUint(v2, 10, bitSize)
+		v2, _ := vd.read(&models.ResourceOperation{}, deviceName, dr, minStr, maxStr, db)
+		i2 := getUintValue(v2)
 		if i1 != i2 {
-			t.Fatalf("EnableRandomization is false, but got different value")
+			t.Fatalf("EnableRandomization is false, but got different read")
 		}
 	}
 }
 
-func SubTestValueFloatx(t *testing.T, dr string) {
+func ValueFloatx(t *testing.T, dr, minStr, maxStr string) {
 	db := getDb()
 	if err := db.openDb(); err != nil {
 		t.Fatal(err)
@@ -336,35 +315,22 @@ func SubTestValueFloatx(t *testing.T, dr string) {
 		}
 	}()
 
-	rd := newVirtualDevice()
-
-	var minFloat, maxFloat float64
-	var bitSize, prec int
-	switch dr {
-	case DeviceResource_Float32:
-		minFloat, maxFloat = rd.minFloat32, rd.maxFloat32
-		bitSize, prec = 32, 6
-	case DeviceResource_Float64:
-		minFloat, maxFloat = rd.minFloat64, rd.maxFloat64
-		bitSize, prec = 64, 15
-	default:
-		t.Fatal("unknown device resource:", dr)
+	//EnableRandomization = true
+	if err := db.exec(SQL_UPDATE_ENABLERANDOMIZATION, true, deviceName, dr); err != nil {
+		t.Fatal(err)
 	}
 
-	if _, err := rd.value(DeviceName, dr, strconv.FormatFloat(minFloat-1, 'f', prec, bitSize), strconv.FormatFloat(maxFloat, 'f', prec, bitSize), db); err == nil {
-		t.Fatalf("when using the minimum value of %s to minus 1, expected to get an error", dr)
-	}
-	if _, err := rd.value(DeviceName, dr, strconv.FormatFloat(minFloat, 'f', prec, bitSize), strconv.FormatFloat(maxFloat+1, 'f', prec, bitSize), db); err == nil {
-		t.Fatalf("when using the maximum value of %s to plus 1, expected to get an error", dr)
-	}
+	vd := newVirtualDevice()
 
 	rounds := 100
 
-	//EnableRandomization = true
+	min, _ := parseStrToFloat(minStr, 64)
+	max, _ := parseStrToFloat(maxStr, 64)
+
+	var f1 float64
 	for x := 1; x <= rounds; x++ {
-		vn, _ := rd.value(DeviceName, dr, strconv.FormatFloat(minFloat, 'f', prec, bitSize), strconv.FormatFloat(maxFloat, 'f', prec, bitSize), db)
-		fn, _ := strconv.ParseFloat(vn, bitSize)
-		var f1 float64
+		vn, _ := vd.read(&models.ResourceOperation{}, deviceName, dr, minStr, maxStr, db)
+		fn := getFloatValue(vn)
 		if x == 1 {
 			f1 = fn
 		}
@@ -372,37 +338,90 @@ func SubTestValueFloatx(t *testing.T, dr string) {
 			break
 		}
 		if x == rounds {
-			t.Fatalf("EnableRandomization is true, but got same value in %d rounds", rounds)
+			t.Fatalf("EnableRandomization is true, but got same read in %d rounds", rounds)
 		}
 	}
 
-	//generate value 100 times
+	//generate read 100 times
 	for x := 1; x <= rounds; x++ {
-		v, err := rd.value(DeviceName, dr, strconv.FormatFloat(minFloat, 'f', prec, bitSize), strconv.FormatFloat(maxFloat, 'f', prec, bitSize), db)
+		v, err := vd.read(&models.ResourceOperation{}, deviceName, dr, minStr, maxStr, db)
 		if err != nil {
 			t.Fatal(err)
 		}
-		f, err := strconv.ParseFloat(v, bitSize)
+		f := getFloatValue(v)
 		if err != nil {
 			t.Fatal(err)
 		}
-		if f < minFloat || f > maxFloat {
-			t.Fatalf("random value: %f,  out of range: %f ~ %f", f, minFloat, maxFloat)
+		if minStr != "" && maxStr != "" {
+			if f < min || f > max {
+				t.Fatalf("random read: %f,  out of range: %f ~ %f", f, min, max)
+			}
 		}
 	}
 
 	//EnableRandomization = false
-	if err := db.exec(SQL_UPDATE_ENABLERANDOMIZATION, false, DeviceName, dr); err != nil {
+	if err := db.exec(SQL_UPDATE_ENABLERANDOMIZATION, false, deviceName, dr); err != nil {
 		t.Fatal(err)
 	}
 
-	v1, _ := rd.value(DeviceName, dr, strconv.FormatFloat(minFloat, 'f', prec, bitSize), strconv.FormatFloat(maxFloat, 'f', prec, bitSize), db)
-	f1, _ := strconv.ParseFloat(v1, bitSize)
+	v1, _ := vd.read(&models.ResourceOperation{}, deviceName, dr, minStr, maxStr, db)
+	f1 = getFloatValue(v1)
 	for x := 1; x <= rounds; x++ {
-		v2, _ := rd.value(DeviceName, dr, strconv.FormatFloat(minFloat, 'f', prec, bitSize), strconv.FormatFloat(maxFloat, 'f', prec, bitSize), db)
-		f2, _ := strconv.ParseFloat(v2, bitSize)
+		v2, _ := vd.read(&models.ResourceOperation{}, deviceName, dr, minStr, maxStr, db)
+		f2 := getFloatValue(v2)
 		if f1 != f2 {
-			t.Fatalf("EnableRandomization is false, but got different value")
+			t.Fatalf("EnableRandomization is false, but got different read")
 		}
+	}
+}
+
+func getIntValue(cv *dsModels.CommandValue) int64 {
+	switch cv.Type {
+	case dsModels.Int8:
+		v, _ := cv.Int8Value()
+		return int64(v)
+	case dsModels.Int16:
+		v, _ := cv.Int16Value()
+		return int64(v)
+	case dsModels.Int32:
+		v, _ := cv.Int32Value()
+		return int64(v)
+	case dsModels.Int64:
+		v, _ := cv.Int64Value()
+		return v
+	default:
+		return 0
+	}
+}
+
+func getUintValue(cv *dsModels.CommandValue) uint64 {
+	switch cv.Type {
+	case dsModels.Uint8:
+		v, _ := cv.Uint8Value()
+		return uint64(v)
+	case dsModels.Uint16:
+		v, _ := cv.Uint16Value()
+		return uint64(v)
+	case dsModels.Uint32:
+		v, _ := cv.Uint32Value()
+		return uint64(v)
+	case dsModels.Uint64:
+		v, _ := cv.Uint64Value()
+		return v
+	default:
+		return 0
+	}
+}
+
+func getFloatValue(cv *dsModels.CommandValue) float64 {
+	switch cv.Type {
+	case dsModels.Float32:
+		v, _ := cv.Float32Value()
+		return float64(v)
+	case dsModels.Float64:
+		v, _ := cv.Float64Value()
+		return v
+	default:
+		return 0
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -1,11 +1,10 @@
 module github.com/edgexfoundry/device-virtual-go
 
 require (
-	github.com/edgexfoundry/device-sdk-go v0.0.0-20190225082215-79877e5ffe07
-	github.com/edgexfoundry/go-mod-core-contracts v0.0.0-20190222195937-d11dc767d321
+	github.com/edgexfoundry/device-sdk-go v0.0.0-20190314211100-54daee7307aa
+	github.com/edgexfoundry/go-mod-core-contracts v0.0.0-20190306124903-4425df9b51ed
 	github.com/edsrzf/mmap-go v1.0.0 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20170806203942-52369c62f446 // indirect
-	golang.org/x/sys v0.0.0-20190225065934-cc5685c2db12 // indirect
 	modernc.org/b v1.0.0 // indirect
 	modernc.org/db v1.0.0 // indirect
 	modernc.org/file v1.0.0 // indirect


### PR DESCRIPTION
1. Remove minimum and maximum attributes from virtual-device profiles.
2. When reading a random value, virtual device will return a random value
in range by data type.
3. Still can assign the minimum and maximum attributes of resource in
virtual-device profile, and it works.
5. To simplify data display, the default device profile doesn't include
int64, uint64, and float64 resources. If you want to use the above
resources, please take a look at cmd/res/example/*.yaml
6. [config] Update pre-configured Device.
7. [config] Remove Schedule* initialization.

Resolves: #1 #3

Signed-off-by: Felix Ting <felix@iotechsys.com>